### PR TITLE
Feature/#17 Share Extension 기능 Set Up

### DIFF
--- a/BestWish.xcodeproj/project.pbxproj
+++ b/BestWish.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 			membershipExceptions = (
 				Data/Network/DTO/AblyResponseDTO.swift,
 				Data/Network/DTO/ProductMetadataDTO.swift,
+				Data/Network/Error/ShareExtensionError.swift,
 				Data/Network/Service/ShareExtension/AblyFetcher.swift,
 				Data/Network/Service/ShareExtension/MusinsaFetcher.swift,
 				Data/Network/Service/ShareExtension/ShareExtensionService.swift,
@@ -458,7 +459,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.ac.indck.hyun.BestWish.BestWishShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.ac.indck.hyun.BestWish.BestWish.BestWishShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -485,7 +486,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.ac.indck.hyun.BestWish.BestWishShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.ac.indck.hyun.BestWish.BestWish.BestWishShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/BestWish.xcodeproj/project.pbxproj
+++ b/BestWish.xcodeproj/project.pbxproj
@@ -447,7 +447,7 @@
 				CODE_SIGN_ENTITLEMENTS = BestWishShareExtension/BestWishShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = DD66GTY4AT;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BestWishShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BestWishShareExtension;
@@ -474,7 +474,7 @@
 				CODE_SIGN_ENTITLEMENTS = BestWishShareExtension/BestWishShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = DD66GTY4AT;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BestWishShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BestWishShareExtension;
@@ -505,7 +505,7 @@
 				CODE_SIGN_ENTITLEMENTS = BestWish/BestWish.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = DD66GTY4AT;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BestWish/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -536,7 +536,7 @@
 				CODE_SIGN_ENTITLEMENTS = BestWish/BestWish.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = DD66GTY4AT;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BestWish/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/BestWish.xcodeproj/project.pbxproj
+++ b/BestWish.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14B8B6432DF6861400B7F5F8 /* BestWishShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 14B8B6392DF6861400B7F5F8 /* BestWishShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		14B8B66D2DF6919700B7F5F8 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 14B8B66C2DF6919700B7F5F8 /* Kingfisher */; };
+		14B8B66F2DF691AA00B7F5F8 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 14B8B66E2DF691AA00B7F5F8 /* RxSwift */; };
+		14B8B6712DF691B300B7F5F8 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 14B8B6702DF691B300B7F5F8 /* SnapKit */; };
+		14B8B6732DF691BC00B7F5F8 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 14B8B6722DF691BC00B7F5F8 /* Then */; };
 		86F6FD012DF66C8B00CAF678 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 86F6FD002DF66C8B00CAF678 /* Alamofire */; };
 		CBD6BA6B2DEF363A003242CA /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = CBD6BA6A2DEF363A003242CA /* RxCocoa */; };
 		CBD6BA6D2DEF363A003242CA /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = CBD6BA6C2DEF363A003242CA /* RxRelay */; };
@@ -17,6 +22,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		14B8B6412DF6861400B7F5F8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CBD6BA092DEF1B39003242CA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 14B8B6382DF6861400B7F5F8;
+			remoteInfo = BestWishShareExtension;
+		};
 		CBD6BA282DEF1B3B003242CA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CBD6BA092DEF1B39003242CA /* Project object */;
@@ -33,13 +45,50 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		14B8B6442DF6861400B7F5F8 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				14B8B6432DF6861400B7F5F8 /* BestWishShareExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		14B8B6392DF6861400B7F5F8 /* BestWishShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BestWishShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBD6BA112DEF1B39003242CA /* BestWish.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BestWish.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBD6BA272DEF1B3B003242CA /* BestWishTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BestWishTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBD6BA312DEF1B3B003242CA /* BestWishUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BestWishUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		14B8B6482DF6861400B7F5F8 /* Exceptions for "BestWishShareExtension" folder in "BestWishShareExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 14B8B6382DF6861400B7F5F8 /* BestWishShareExtension */;
+		};
+		14B8B6632DF68EEF00B7F5F8 /* Exceptions for "BestWish" folder in "BestWishShareExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Data/Network/DTO/AblyResponseDTO.swift,
+				Data/Network/DTO/ProductMetadataDTO.swift,
+				Data/Network/Service/ShareExtension/AblyFetcher.swift,
+				Data/Network/Service/ShareExtension/MusinsaFetcher.swift,
+				Data/Network/Service/ShareExtension/ShareExtensionService.swift,
+				Data/Network/Service/ShareExtension/ZigzagFetcher.swift,
+				Domain/Entity/SharePlatform.swift,
+				Domain/Interface/MetadataFetcherRepository.swift,
+				"Presentation/Extension/String+Extension.swift",
+			);
+			target = 14B8B6382DF6861400B7F5F8 /* BestWishShareExtension */;
+		};
 		CBD6BA392DEF1B3B003242CA /* Exceptions for "BestWish" folder in "BestWish" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -50,10 +99,19 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		14B8B63A2DF6861400B7F5F8 /* BestWishShareExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				14B8B6482DF6861400B7F5F8 /* Exceptions for "BestWishShareExtension" folder in "BestWishShareExtension" target */,
+			);
+			path = BestWishShareExtension;
+			sourceTree = "<group>";
+		};
 		CBD6BA132DEF1B39003242CA /* BestWish */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				CBD6BA392DEF1B3B003242CA /* Exceptions for "BestWish" folder in "BestWish" target */,
+				14B8B6632DF68EEF00B7F5F8 /* Exceptions for "BestWish" folder in "BestWishShareExtension" target */,
 			);
 			path = BestWish;
 			sourceTree = "<group>";
@@ -71,6 +129,17 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		14B8B6362DF6861400B7F5F8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				14B8B6712DF691B300B7F5F8 /* SnapKit in Frameworks */,
+				14B8B66F2DF691AA00B7F5F8 /* RxSwift in Frameworks */,
+				14B8B66D2DF6919700B7F5F8 /* Kingfisher in Frameworks */,
+				14B8B6732DF691BC00B7F5F8 /* Then in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CBD6BA0E2DEF1B39003242CA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -108,6 +177,7 @@
 				CBD6BA132DEF1B39003242CA /* BestWish */,
 				CBD6BA2A2DEF1B3B003242CA /* BestWishTests */,
 				CBD6BA342DEF1B3B003242CA /* BestWishUITests */,
+				14B8B63A2DF6861400B7F5F8 /* BestWishShareExtension */,
 				CBD6BA122DEF1B39003242CA /* Products */,
 			);
 			sourceTree = "<group>";
@@ -118,6 +188,7 @@
 				CBD6BA112DEF1B39003242CA /* BestWish.app */,
 				CBD6BA272DEF1B3B003242CA /* BestWishTests.xctest */,
 				CBD6BA312DEF1B3B003242CA /* BestWishUITests.xctest */,
+				14B8B6392DF6861400B7F5F8 /* BestWishShareExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -125,6 +196,32 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		14B8B6382DF6861400B7F5F8 /* BestWishShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 14B8B6472DF6861400B7F5F8 /* Build configuration list for PBXNativeTarget "BestWishShareExtension" */;
+			buildPhases = (
+				14B8B6352DF6861400B7F5F8 /* Sources */,
+				14B8B6362DF6861400B7F5F8 /* Frameworks */,
+				14B8B6372DF6861400B7F5F8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				14B8B63A2DF6861400B7F5F8 /* BestWishShareExtension */,
+			);
+			name = BestWishShareExtension;
+			packageProductDependencies = (
+				14B8B66C2DF6919700B7F5F8 /* Kingfisher */,
+				14B8B66E2DF691AA00B7F5F8 /* RxSwift */,
+				14B8B6702DF691B300B7F5F8 /* SnapKit */,
+				14B8B6722DF691BC00B7F5F8 /* Then */,
+			);
+			productName = BestWishShareExtension;
+			productReference = 14B8B6392DF6861400B7F5F8 /* BestWishShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		CBD6BA102DEF1B39003242CA /* BestWish */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CBD6BA3A2DEF1B3B003242CA /* Build configuration list for PBXNativeTarget "BestWish" */;
@@ -132,10 +229,12 @@
 				CBD6BA0D2DEF1B39003242CA /* Sources */,
 				CBD6BA0E2DEF1B39003242CA /* Frameworks */,
 				CBD6BA0F2DEF1B39003242CA /* Resources */,
+				14B8B6442DF6861400B7F5F8 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				14B8B6422DF6861400B7F5F8 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				CBD6BA132DEF1B39003242CA /* BestWish */,
@@ -207,9 +306,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1640;
+				LastSwiftUpdateCheck = 1630;
 				LastUpgradeCheck = 1640;
 				TargetAttributes = {
+					14B8B6382DF6861400B7F5F8 = {
+						CreatedOnToolsVersion = 16.3;
+					};
 					CBD6BA102DEF1B39003242CA = {
 						CreatedOnToolsVersion = 16.4;
 					};
@@ -249,11 +351,19 @@
 				CBD6BA102DEF1B39003242CA /* BestWish */,
 				CBD6BA262DEF1B3B003242CA /* BestWishTests */,
 				CBD6BA302DEF1B3B003242CA /* BestWishUITests */,
+				14B8B6382DF6861400B7F5F8 /* BestWishShareExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		14B8B6372DF6861400B7F5F8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CBD6BA0F2DEF1B39003242CA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -278,6 +388,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		14B8B6352DF6861400B7F5F8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CBD6BA0D2DEF1B39003242CA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -302,6 +419,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		14B8B6422DF6861400B7F5F8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 14B8B6382DF6861400B7F5F8 /* BestWishShareExtension */;
+			targetProxy = 14B8B6412DF6861400B7F5F8 /* PBXContainerItemProxy */;
+		};
 		CBD6BA292DEF1B3B003242CA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = CBD6BA102DEF1B39003242CA /* BestWish */;
@@ -315,6 +437,56 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		14B8B6452DF6861400B7F5F8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BestWishShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = BestWishShareExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.ac.indck.hyun.BestWish.BestWishShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		14B8B6462DF6861400B7F5F8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BestWishShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = BestWishShareExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.ac.indck.hyun.BestWish.BestWishShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		CBD6BA3B2DEF1B3B003242CA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = CBD6BA132DEF1B39003242CA /* BestWish */;
@@ -577,6 +749,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		14B8B6472DF6861400B7F5F8 /* Build configuration list for PBXNativeTarget "BestWishShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				14B8B6452DF6861400B7F5F8 /* Debug */,
+				14B8B6462DF6861400B7F5F8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		CBD6BA0C2DEF1B39003242CA /* Build configuration list for PBXProject "BestWish" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -667,6 +848,26 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		14B8B66C2DF6919700B7F5F8 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CBD6BA742DEF370B003242CA /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
+		};
+		14B8B66E2DF691AA00B7F5F8 /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CBD6BA692DEF363A003242CA /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		14B8B6702DF691B300B7F5F8 /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CBD6BA6E2DEF364D003242CA /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+		14B8B6722DF691BC00B7F5F8 /* Then */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CBD6BA712DEF3656003242CA /* XCRemoteSwiftPackageReference "Then" */;
+			productName = Then;
+		};
 		86F6FD002DF66C8B00CAF678 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 86F6FCFF2DF66C8B00CAF678 /* XCRemoteSwiftPackageReference "Alamofire" */;

--- a/BestWish.xcodeproj/project.pbxproj
+++ b/BestWish.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		14B8B66F2DF691AA00B7F5F8 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 14B8B66E2DF691AA00B7F5F8 /* RxSwift */; };
 		14B8B6712DF691B300B7F5F8 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 14B8B6702DF691B300B7F5F8 /* SnapKit */; };
 		14B8B6732DF691BC00B7F5F8 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 14B8B6722DF691BC00B7F5F8 /* Then */; };
+		14B8B6792DF6C57000B7F5F8 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 14B8B6782DF6C57000B7F5F8 /* RxCocoa */; };
 		86F6FD012DF66C8B00CAF678 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 86F6FD002DF66C8B00CAF678 /* Alamofire */; };
 		CBD6BA6B2DEF363A003242CA /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = CBD6BA6A2DEF363A003242CA /* RxCocoa */; };
 		CBD6BA6D2DEF363A003242CA /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = CBD6BA6C2DEF363A003242CA /* RxRelay */; };
@@ -135,6 +136,7 @@
 			files = (
 				14B8B6712DF691B300B7F5F8 /* SnapKit in Frameworks */,
 				14B8B66F2DF691AA00B7F5F8 /* RxSwift in Frameworks */,
+				14B8B6792DF6C57000B7F5F8 /* RxCocoa in Frameworks */,
 				14B8B66D2DF6919700B7F5F8 /* Kingfisher in Frameworks */,
 				14B8B6732DF691BC00B7F5F8 /* Then in Frameworks */,
 			);
@@ -217,6 +219,7 @@
 				14B8B66E2DF691AA00B7F5F8 /* RxSwift */,
 				14B8B6702DF691B300B7F5F8 /* SnapKit */,
 				14B8B6722DF691BC00B7F5F8 /* Then */,
+				14B8B6782DF6C57000B7F5F8 /* RxCocoa */,
 			);
 			productName = BestWishShareExtension;
 			productReference = 14B8B6392DF6861400B7F5F8 /* BestWishShareExtension.appex */;
@@ -440,8 +443,10 @@
 		14B8B6452DF6861400B7F5F8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = BestWishShareExtension/BestWishShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DD66GTY4AT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BestWishShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BestWishShareExtension;
@@ -465,8 +470,10 @@
 		14B8B6462DF6861400B7F5F8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = BestWishShareExtension/BestWishShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DD66GTY4AT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BestWishShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BestWishShareExtension;
@@ -494,8 +501,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = BestWish/BestWish.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DD66GTY4AT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BestWish/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -523,8 +532,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = BestWish/BestWish.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DD66GTY4AT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BestWish/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -867,6 +878,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CBD6BA712DEF3656003242CA /* XCRemoteSwiftPackageReference "Then" */;
 			productName = Then;
+		};
+		14B8B6782DF6C57000B7F5F8 /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CBD6BA692DEF363A003242CA /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
 		};
 		86F6FD002DF66C8B00CAF678 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/BestWish/BestWish.entitlements
+++ b/BestWish/BestWish.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.baekyeong.bestwish</string>
+	</array>
+</dict>
+</plist>

--- a/BestWish/Data/Network/DTO/AblyResponseDTO.swift
+++ b/BestWish/Data/Network/DTO/AblyResponseDTO.swift
@@ -1,0 +1,67 @@
+//
+//  AblyResponseDTO.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import Foundation
+
+struct AblyResponseDTO: Codable {
+    let props: Props
+}
+
+struct Props: Codable {
+    let pageProps: PageProps
+    let serverQueryClient: ServerQueryClient
+}
+
+struct PageProps: Codable {
+//    let serverQueryClient: ServerQueryClient
+}
+
+struct ServerQueryClient: Codable {
+    let queries: [Query]
+}
+
+struct Query: Codable {
+    let state: State2
+}
+
+struct State2: Codable {
+    let data: GoodsData
+}
+
+struct GoodsData: Codable {
+    let goods: Goods
+}
+
+struct Goods: Codable {
+    let name: String?
+    let priceInfo: PriceInfo
+    let market: Market
+    let coverImages: [String]
+    
+    enum CodingKeys: String, CodingKey {
+        case name, market
+        case priceInfo = "price_info"
+        case coverImages = "cover_images"
+    }
+}
+
+struct PriceInfo: Codable {
+    let consumer: Int?
+    let thumbnailPrice: Int?
+    let discountRate: Int?
+    
+    enum CodingKeys: String, CodingKey {
+        case consumer
+        case thumbnailPrice = "thumbnail_price"
+        case discountRate = "discount_rate"
+    }
+}
+
+struct Market: Codable {
+    let name: String?
+    let image: String?
+}

--- a/BestWish/Data/Network/DTO/AblyResponseDTO.swift
+++ b/BestWish/Data/Network/DTO/AblyResponseDTO.swift
@@ -37,13 +37,14 @@ struct GoodsData: Codable {
 }
 
 struct Goods: Codable {
+    let sno: Int?
     let name: String?
     let priceInfo: PriceInfo
     let market: Market
     let coverImages: [String]
     
     enum CodingKeys: String, CodingKey {
-        case name, market
+        case sno, name, market
         case priceInfo = "price_info"
         case coverImages = "cover_images"
     }

--- a/BestWish/Data/Network/DTO/ProductMetadataDTO.swift
+++ b/BestWish/Data/Network/DTO/ProductMetadataDTO.swift
@@ -1,0 +1,19 @@
+//
+//  ProductMetadataDTO.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import Foundation
+
+// MARK: - 상품 메타데이터 모델
+struct ProductMetadataDTO {
+    let productName: String?
+    let brandName: String?
+    let discountRate: String?
+    let price: String?
+    let imageURL: String?
+    let productURL: URL?
+    let extra: String?
+}

--- a/BestWish/Data/Network/Error/ShareExtensionError.swift
+++ b/BestWish/Data/Network/Error/ShareExtensionError.swift
@@ -1,0 +1,20 @@
+//
+//  ShareExtensionError.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/10/25.
+//
+
+import Foundation
+
+enum ShareExtensionError: Error {
+    case invaildURL
+    case platformDetectionFailed
+    case redirectionFailed
+    case htmlParsingFailed
+    case dataLoadingFailed
+    case jsonScriptParsingFailed
+    case jsonDecodingFailed
+    case invalidProductData
+    case unknown
+}

--- a/BestWish/Data/Network/Service/ShareExtension/AblyFetcher.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/AblyFetcher.swift
@@ -15,29 +15,36 @@ class AblyFetcher: ShareMetadataFetcher {
         return Single<ProductMetadataDTO>.create { single in
             let task = URLSession.shared.dataTask(with: extraUrl) { data, _, error in
                 guard let data, let html = String(data: data, encoding: .utf8) else {
-                    single(.failure(error ?? NSError(domain: "AblyFetcher", code: -1)))
+                    single(.failure(error ?? ShareExtensionError.dataLoadingFailed))
                     return
                 }
                 guard let nextDataJSON = html.extractNEXTDataJSON(),
                       let jsonData = nextDataJSON.data(using: .utf8) else {
-                    single(.failure(NSError(domain: "AblyFetcher", code: -2)))
+                    single(.failure(ShareExtensionError.jsonScriptParsingFailed))
                     return
                 }
+                
                 do {
                     let decoded = try JSONDecoder().decode(AblyResponseDTO.self, from: jsonData)
-                    let goods = decoded.props.serverQueryClient.queries.first?.state.data.goods
+                    guard let goods = decoded.props.serverQueryClient.queries.first?.state.data.goods,
+                          let sno = goods.sno else {
+                        single(.failure(ShareExtensionError.invalidProductData))
+                        return
+                    }
+                    
+                    let deeplink = "ably://goods/\(sno)"
                     let metadata = ProductMetadataDTO(
-                        productName: goods?.name,
-                        brandName: goods?.market.name,
-                        discountRate: "\(goods?.priceInfo.discountRate ?? 0)",
-                        price: "\(goods?.priceInfo.thumbnailPrice ?? 0)",
-                        imageURL: goods?.coverImages.first,
-                        productURL: extraUrl,
+                        productName: goods.name,
+                        brandName: goods.market.name,
+                        discountRate: "\(goods.priceInfo.discountRate ?? 0)",
+                        price: "\(goods.priceInfo.thumbnailPrice ?? 0)",
+                        imageURL: goods.coverImages.first,
+                        productURL: URL(string: deeplink),
                         extra: nil
                     )
                     single(.success(metadata))
                 } catch {
-                    single(.failure(error))
+                    single(.failure(ShareExtensionError.jsonDecodingFailed))
                 }
             }
             task.resume()

--- a/BestWish/Data/Network/Service/ShareExtension/AblyFetcher.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/AblyFetcher.swift
@@ -1,0 +1,47 @@
+//
+//  AblyFetcher.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import Foundation
+
+import RxSwift
+
+// MARK: - Ably Fetcher
+class AblyFetcher: ShareMetadataFetcher {
+    func fetchMetadata(from url: URL) -> Single<ProductMetadataDTO> {
+        return Single<ProductMetadataDTO>.create { single in
+            let task = URLSession.shared.dataTask(with: url) { data, _, error in
+                guard let data, let html = String(data: data, encoding: .utf8) else {
+                    single(.failure(error ?? NSError(domain: "AblyFetcher", code: -1)))
+                    return
+                }
+                guard let nextDataJSON = html.extractNEXTDataJSON(),
+                      let jsonData = nextDataJSON.data(using: .utf8) else {
+                    single(.failure(NSError(domain: "AblyFetcher", code: -2)))
+                    return
+                }
+                do {
+                    let decoded = try JSONDecoder().decode(AblyResponseDTO.self, from: jsonData)
+                    let goods = decoded.props.serverQueryClient.queries.first?.state.data.goods
+                    let metadata = ProductMetadataDTO(
+                        productName: goods?.name,
+                        brandName: goods?.market.name,
+                        discountRate: "\(goods?.priceInfo.discountRate ?? 0)",
+                        price: "\(goods?.priceInfo.thumbnailPrice ?? 0)",
+                        imageURL: goods?.coverImages.first,
+                        productURL: url,
+                        extra: nil
+                    )
+                    single(.success(metadata))
+                } catch {
+                    single(.failure(error))
+                }
+            }
+            task.resume()
+            return Disposables.create { task.cancel() }
+        }
+    }
+}

--- a/BestWish/Data/Network/Service/ShareExtension/AblyFetcher.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/AblyFetcher.swift
@@ -11,9 +11,9 @@ import RxSwift
 
 // MARK: - Ably Fetcher
 class AblyFetcher: ShareMetadataFetcher {
-    func fetchMetadata(from url: URL) -> Single<ProductMetadataDTO> {
+    func fetchMetadata(ogUrl: URL, extraUrl: URL) -> Single<ProductMetadataDTO> {
         return Single<ProductMetadataDTO>.create { single in
-            let task = URLSession.shared.dataTask(with: url) { data, _, error in
+            let task = URLSession.shared.dataTask(with: extraUrl) { data, _, error in
                 guard let data, let html = String(data: data, encoding: .utf8) else {
                     single(.failure(error ?? NSError(domain: "AblyFetcher", code: -1)))
                     return
@@ -32,7 +32,7 @@ class AblyFetcher: ShareMetadataFetcher {
                         discountRate: "\(goods?.priceInfo.discountRate ?? 0)",
                         price: "\(goods?.priceInfo.thumbnailPrice ?? 0)",
                         imageURL: goods?.coverImages.first,
-                        productURL: url,
+                        productURL: extraUrl,
                         extra: nil
                     )
                     single(.success(metadata))

--- a/BestWish/Data/Network/Service/ShareExtension/MusinsaFetcher.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/MusinsaFetcher.swift
@@ -15,14 +15,15 @@ class MusinsaFetcher: ShareMetadataFetcher {
         return Single<ProductMetadataDTO>.create { single in
             let task = URLSession.shared.dataTask(with: extraUrl) { data, _, error in
                 guard let data, let html = String(data: data, encoding: .utf8) else {
-                    single(.failure(error ?? NSError(domain: "MusinsaFetcher", code: -1)))
+                    single(.failure(error ?? ShareExtensionError.dataLoadingFailed))
                     return
                 }
                 // HTML에서 리디렉션된 상품 URL 확인
                 if let productURLString = html.firstMatch(for: #"link=(https:\/\/www\.musinsa\.com\/products\/\d+)"#),
-                   let productURL = URL(string: productURLString) {
-                    // 리디렉션된 URL에 대한 재귀 호출
-                    _ = self.fetchMetadata(ogUrl: ogUrl, extraUrl: extraUrl).subscribe(single)
+                   let redirectedURL = URL(string: productURLString),
+                   redirectedURL != extraUrl {
+                    // 리디렉션된 URL이 현재 URL과 다를 때만 재귀 호출
+                    _ = self.fetchMetadata(ogUrl: ogUrl, extraUrl: redirectedURL).subscribe(single)
                     return
                 }
                 

--- a/BestWish/Data/Network/Service/ShareExtension/MusinsaFetcher.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/MusinsaFetcher.swift
@@ -1,0 +1,62 @@
+//
+//  MusinsaFetcher.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import Foundation
+
+import RxSwift
+
+// MARK: - Musinsa Fetcher
+class MusinsaFetcher: ShareMetadataFetcher {
+    func fetchMetadata(from url: URL) -> Single<ProductMetadataDTO> {
+        return Single<ProductMetadataDTO>.create { single in
+            let task = URLSession.shared.dataTask(with: url) { data, _, error in
+                guard let data, let html = String(data: data, encoding: .utf8) else {
+                    single(.failure(error ?? NSError(domain: "MusinsaFetcher", code: -1)))
+                    return
+                }
+                // HTML에서 리디렉션된 상품 URL 확인
+                if let productURLString = html.firstMatch(for: #"link=(https:\/\/www\.musinsa\.com\/products\/\d+)"#),
+                   let productURL = URL(string: productURLString) {
+                    // 리디렉션된 URL에 대한 재귀 호출
+                    _ = self.fetchMetadata(from: productURL).subscribe(single)
+                    return
+                }
+                
+                let title = html.slice(from: "property=\"og:title\" content=\"", to: "\"")
+                let image = html.slice(from: "property=\"og:image\" content=\"", to: "\"")
+                let saleRate = html.slice(from: "property=\"product:price:sale_rate\" content=\"", to: "\"")
+                let amountPrice = html.slice(from: "property=\"product:price:amount\" content=\"", to: "\"")
+                // Parse brand and product name
+                let (brand, product, extra) = MusinsaFetcher.parseTitle(title ?? "")
+                let metadata = ProductMetadataDTO(
+                    productName: product,
+                    brandName: brand,
+                    discountRate: saleRate,
+                    price: amountPrice,
+                    imageURL: image,
+                    productURL: url,
+                    extra: extra
+                )
+                single(.success(metadata))
+            }
+            task.resume()
+            return Disposables.create { task.cancel() }
+        }
+    }
+
+    private static func parseTitle(_ title: String) -> (brand: String?, product: String?, extra: String?) {
+        guard let firstSpaceRange = title.range(of: " ") else {
+            return (nil, nil, nil)
+        }
+        let brand = String(title[..<firstSpaceRange.lowerBound])
+        let remainder = String(title[firstSpaceRange.upperBound...])
+        let productAndExtra = remainder.components(separatedBy: " - ")
+        let product = productAndExtra.first
+        let extra = productAndExtra.count > 1 ? productAndExtra[1] : nil
+        return (brand, product, extra)
+    }
+}

--- a/BestWish/Data/Network/Service/ShareExtension/MusinsaFetcher.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/MusinsaFetcher.swift
@@ -11,9 +11,9 @@ import RxSwift
 
 // MARK: - Musinsa Fetcher
 class MusinsaFetcher: ShareMetadataFetcher {
-    func fetchMetadata(from url: URL) -> Single<ProductMetadataDTO> {
+    func fetchMetadata(ogUrl: URL, extraUrl: URL) -> Single<ProductMetadataDTO> {
         return Single<ProductMetadataDTO>.create { single in
-            let task = URLSession.shared.dataTask(with: url) { data, _, error in
+            let task = URLSession.shared.dataTask(with: extraUrl) { data, _, error in
                 guard let data, let html = String(data: data, encoding: .utf8) else {
                     single(.failure(error ?? NSError(domain: "MusinsaFetcher", code: -1)))
                     return
@@ -22,7 +22,7 @@ class MusinsaFetcher: ShareMetadataFetcher {
                 if let productURLString = html.firstMatch(for: #"link=(https:\/\/www\.musinsa\.com\/products\/\d+)"#),
                    let productURL = URL(string: productURLString) {
                     // 리디렉션된 URL에 대한 재귀 호출
-                    _ = self.fetchMetadata(from: productURL).subscribe(single)
+                    _ = self.fetchMetadata(ogUrl: ogUrl, extraUrl: extraUrl).subscribe(single)
                     return
                 }
                 
@@ -38,7 +38,7 @@ class MusinsaFetcher: ShareMetadataFetcher {
                     discountRate: saleRate,
                     price: amountPrice,
                     imageURL: image,
-                    productURL: url,
+                    productURL: ogUrl,
                     extra: extra
                 )
                 single(.success(metadata))

--- a/BestWish/Data/Network/Service/ShareExtension/ShareExtensionService.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/ShareExtensionService.swift
@@ -1,0 +1,110 @@
+//
+//  ShareExtensionService.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import Foundation
+
+import RxSwift
+
+// MARK: - ShareExtensionService
+final class ShareExtensionService {
+    static let shared = ShareExtensionService()
+    
+    private init() {}
+    
+    // MARK: 쇼핑 플랫폼 감지
+    private func detectPlatform(from text: String) -> SharePlatform {
+        if text.contains("musinsa") {
+            return .musinsa
+        } else if text.contains("zigzag") {
+            return .zigzag
+        } else if text.contains("a-bly") {
+            return .ably
+        }
+        return .unknown
+    }
+    
+    // MARK: - 텍스트 내 URL 추출
+    static func extractURL(from text: String) -> URL? {
+        let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        let matches = detector?.matches(in: text, options: [], range: NSRange(location: 0, length: text.utf16.count))
+        return matches?.first?.url
+    }
+
+    // MARK: - URL 요청을 통해 리디렉션된 최종 URL 반환 (공통)
+    func resolveFinalURL(url: URL) -> Single<URL> {
+        return Single<URL>.create { single in
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.timeoutInterval = 10
+            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            let task = URLSession.shared.dataTask(with: request) { _, response, error in
+                if let finalURL = response?.url {
+                    single(.success(finalURL))
+                } else if let error = error {
+                    single(.failure(error))
+                } else {
+                    single(.failure(NSError(domain: "FinalURL", code: -1, userInfo: nil)))
+                }
+            }
+            task.resume()
+            return Disposables.create { task.cancel() }
+        }
+    }
+
+    // MARK: - URL 요청을 통해 리디렉션된 최종 URL과 html 반환 (지그재그)
+    func resolveZigzagFinalURL(url: URL) -> Single<(URL, String)> {
+        return Single<(URL, String)>.create { single in
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.timeoutInterval = 10
+            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            request.setValue(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+                forHTTPHeaderField: "User-Agent"
+            )
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                if let finalURL = response?.url,
+                   let html = data.flatMap({ String(data: $0, encoding: .utf8) }) {
+                    single(.success((finalURL, html)))
+                } else if let error = error {
+                    single(.failure(error))
+                } else {
+                    single(.failure(NSError(domain: "ZigzagFinalURL", code: -1, userInfo: nil)))
+                }
+            }
+            task.resume()
+            return Disposables.create { task.cancel() }
+        }
+    }
+
+    // MARK: - Fetch Platform Metadata
+    func fetchPlatformMetadata(from sharedText: String) -> Single<ProductMetadataDTO> {
+        let platform = detectPlatform(from: sharedText)
+        guard let url = ShareExtensionService.extractURL(from: sharedText) else {
+            return Single.error(NSError(domain: "NoURL", code: -1, userInfo: [NSLocalizedDescriptionKey: "No URL found in text"]))
+        }
+        switch platform {
+        case .musinsa:
+            return resolveFinalURL(url: url)
+                .flatMap { finalURL in
+                    MusinsaFetcher().fetchMetadata(from: finalURL)
+                }
+        case .zigzag:
+            return resolveZigzagFinalURL(url: url)
+                .flatMap { (finalURL, html) in
+                    ZigzagFetcher().fetchMetadata(from: finalURL, html: html)
+                }
+        case .ably:
+            return resolveFinalURL(url: url)
+                .flatMap { finalURL in
+                    AblyFetcher().fetchMetadata(from: finalURL)
+                }
+        case .unknown:
+            return Single.error(NSError(domain: "Platform", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown platform"]))
+        }
+    }
+}

--- a/BestWish/Data/Network/Service/ShareExtension/ShareExtensionService.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/ShareExtensionService.swift
@@ -44,10 +44,10 @@ final class ShareExtensionService {
             let task = URLSession.shared.dataTask(with: request) { _, response, error in
                 if let finalURL = response?.url {
                     single(.success(finalURL))
-                } else if let error = error {
+                } else if let error {
                     single(.failure(error))
                 } else {
-                    single(.failure(NSError(domain: "FinalURL", code: -1, userInfo: nil)))
+                    single(.failure(ShareExtensionError.redirectionFailed))
                 }
             }
             task.resume()
@@ -73,7 +73,7 @@ final class ShareExtensionService {
                 } else if let error = error {
                     single(.failure(error))
                 } else {
-                    single(.failure(NSError(domain: "ZigzagFinalURL", code: -1, userInfo: nil)))
+                    single(.failure(ShareExtensionError.htmlParsingFailed))
                 }
             }
             task.resume()
@@ -84,7 +84,7 @@ final class ShareExtensionService {
     // MARK: - Fetch Platform Metadata
     func fetchPlatformMetadata(from sharedText: String) -> Single<(String, ProductMetadataDTO)> {
         guard let originalUrl = ShareExtensionService.extractURL(from: sharedText) else {
-            return Single.error(NSError(domain: "NoURL", code: -1, userInfo: [NSLocalizedDescriptionKey: "No URL found in text"]))
+            return Single.error(ShareExtensionError.invaildURL)
         }
         
         let platform = detectPlatform(from: sharedText)
@@ -109,7 +109,7 @@ final class ShareExtensionService {
                         .map { metadata in (originalUrl.absoluteString, metadata) }
                 }
         case .unknown:
-            return Single.error(NSError(domain: "Platform", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown platform"]))
+            return Single.error(ShareExtensionError.platformDetectionFailed)
         }
     }
 }

--- a/BestWish/Data/Network/Service/ShareExtension/ZigzagFetcher.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/ZigzagFetcher.swift
@@ -11,24 +11,124 @@ import RxSwift
 
 // MARK: - Zigzag Fetcher
 class ZigzagFetcher: HTMLBasedMetadataFetcher {
-    func fetchMetadata(from url: URL, html: String) -> Single<ProductMetadataDTO> {
+    func fetchMetadata(ogUrl: URL, extraUrl: URL, html: String) -> Single<ProductMetadataDTO> {
         return Single<ProductMetadataDTO>.create { single in
             let brand = html.slice(from: "property=\"product:brand\" content=\"", to: "\"")
             let title = html.slice(from: "property=\"og:title\" content=\"", to: "\"")
             let image = html.slice(from: "property=\"og:image\" content=\"", to: "\"")
             let amountPrice = html.slice(from: "property=\"product:price:amount\" content=\"", to: "\"")
-
-            let metadata = ProductMetadataDTO(
-                productName: title,
-                brandName: brand,
-                discountRate: "0",
-                price: amountPrice,
-                imageURL: image,
-                productURL: url,
-                extra: nil
-            )
-            single(.success(metadata))
+            
+            if let json = html.extractapplicationLdJson() {
+                let pattern = #""deeplink_url"\s*:\s*"([^"]+)""#
+                if let match = json.firstMatch(for: pattern) {
+                    print("정규식으로 추출된 deeplink_url: \(match)")
+                    
+                    // 수동으로 \\u0026로 분할하여 중복 파라미터 제거
+                    let segments = match.components(separatedBy: #"\u0026"#)
+                    print("정제된 딥링크: \(segments)")
+                    
+                    // 필요한 인덱스만 선택 (0, 2, 3번째 항목)
+                    let filtered = [0, 2, 3].compactMap { $0 < segments.count ? segments[$0] : nil }
+                    let finalDeeplink = filtered.joined(separator: "&")
+                    print("최종 딥링크: \(finalDeeplink)")
+                    
+                    let metadata = ProductMetadataDTO(
+                        productName: title,
+                        brandName: brand,
+                        discountRate: "0",
+                        price: amountPrice,
+                        imageURL: image,
+                        productURL: URL(string: finalDeeplink),
+                        extra: nil
+                    )
+                    single(.success(metadata))
+                }
+            }
             return Disposables.create()
         }
     }
+    
+    func extractZigzagDeeplinkFromScript(in html: String) -> URL? {
+        let pattern = #"<script[^>]*id="__NEXT_DATA__"[^>]*>(.*?)</script>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]),
+              let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+              let range = Range(match.range(at: 1), in: html)
+        else {
+            return nil
+        }
+
+        let jsonString = String(html[range])
+
+        guard let data = jsonString.data(using: .utf8),
+              let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let props = jsonObject["props"] as? [String: Any],
+              let pageProps = props["pageProps"] as? [String: Any],
+              let deeplink = pageProps["deeplink_url"] as? String
+        else {
+            return nil
+        }
+
+        return URL(string: deeplink.removingPercentEncoding ?? deeplink)
+    }
+    
+    func extractDeeplinkURL(from html: String) -> URL? {
+        let pattern = #""deeplink_url"\s*:\s*"([^"]+)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+              let range = Range(match.range(at: 1), in: html)
+        else {
+            return nil
+        }
+
+        let raw = String(html[range])
+        let decoded = raw.removingPercentEncoding ?? raw
+        return URL(string: decoded)
+    }
+    
+    func extractEncodedDeeplinkURL(from html: String) -> URL? {
+        let pattern = #"deeplink_url=([^&\\"]+)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+              let range = Range(match.range(at: 1), in: html)
+        else {
+            return nil
+        }
+
+        let encoded = String(html[range])
+        let decoded = encoded.removingPercentEncoding ?? encoded
+        return URL(string: decoded)
+    }
+    
+    func extractZigzagDeeplink(from html: String) -> URL? {
+        return extractZigzagDeeplinkFromScript(in: html) ??
+               extractDeeplinkURL(from: html) ??
+               extractEncodedDeeplinkURL(from: html)
+    }
+    
+    func extractScriptContent(withId id: String, from html: String) -> String? {
+        let pattern = #"<script[^>]*id="\#(id)"[^>]*>(.*?)</script>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]),
+              let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+              let range = Range(match.range(at: 1), in: html)
+        else {
+            return nil
+        }
+
+        return String(html[range])
+    }
+    
+    func extractScriptContents(ofType type: String, from html: String) -> [String] {
+        let pattern = #"<script[^>]*type="\#(type)"[^>]*>(.*?)</script>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]) else {
+            return []
+        }
+
+        let results = regex.matches(in: html, range: NSRange(html.startIndex..., in: html))
+        return results.compactMap { match in
+            guard let range = Range(match.range(at: 1), in: html) else { return nil }
+            return String(html[range])
+        }
+    }
+    
+    
 }

--- a/BestWish/Data/Network/Service/ShareExtension/ZigzagFetcher.swift
+++ b/BestWish/Data/Network/Service/ShareExtension/ZigzagFetcher.swift
@@ -1,0 +1,34 @@
+//
+//  ZigzagFetcher.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import Foundation
+
+import RxSwift
+
+// MARK: - Zigzag Fetcher
+class ZigzagFetcher: HTMLBasedMetadataFetcher {
+    func fetchMetadata(from url: URL, html: String) -> Single<ProductMetadataDTO> {
+        return Single<ProductMetadataDTO>.create { single in
+            let brand = html.slice(from: "property=\"product:brand\" content=\"", to: "\"")
+            let title = html.slice(from: "property=\"og:title\" content=\"", to: "\"")
+            let image = html.slice(from: "property=\"og:image\" content=\"", to: "\"")
+            let amountPrice = html.slice(from: "property=\"product:price:amount\" content=\"", to: "\"")
+
+            let metadata = ProductMetadataDTO(
+                productName: title,
+                brandName: brand,
+                discountRate: "0",
+                price: amountPrice,
+                imageURL: image,
+                productURL: url,
+                extra: nil
+            )
+            single(.success(metadata))
+            return Disposables.create()
+        }
+    }
+}

--- a/BestWish/Domain/Entity/SharePlatform.swift
+++ b/BestWish/Domain/Entity/SharePlatform.swift
@@ -1,0 +1,16 @@
+//
+//  SharePlatform.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import Foundation
+
+// MARK: - Platform Enum
+enum SharePlatform {
+    case musinsa
+    case zigzag
+    case ably
+    case unknown
+}

--- a/BestWish/Domain/Interface/MetadataFetcherRepository.swift
+++ b/BestWish/Domain/Interface/MetadataFetcherRepository.swift
@@ -11,9 +11,9 @@ import RxSwift
 
 // MARK: - Metadata Fetcher Protocol
 protocol ShareMetadataFetcher {
-    func fetchMetadata(from url: URL) -> Single<ProductMetadataDTO>
+    func fetchMetadata(ogUrl: URL, extraUrl: URL) -> Single<ProductMetadataDTO>
 }
 
 protocol HTMLBasedMetadataFetcher {
-    func fetchMetadata(from url: URL, html: String) -> Single<ProductMetadataDTO>
+    func fetchMetadata(ogUrl: URL, extraUrl: URL, html: String) -> Single<ProductMetadataDTO>
 }

--- a/BestWish/Domain/Interface/MetadataFetcherRepository.swift
+++ b/BestWish/Domain/Interface/MetadataFetcherRepository.swift
@@ -1,0 +1,19 @@
+//
+//  MetadataFetcherRepository.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import Foundation
+
+import RxSwift
+
+// MARK: - Metadata Fetcher Protocol
+protocol ShareMetadataFetcher {
+    func fetchMetadata(from url: URL) -> Single<ProductMetadataDTO>
+}
+
+protocol HTMLBasedMetadataFetcher {
+    func fetchMetadata(from url: URL, html: String) -> Single<ProductMetadataDTO>
+}

--- a/BestWish/Presentation/Extension/String+Extension.swift
+++ b/BestWish/Presentation/Extension/String+Extension.swift
@@ -1,0 +1,37 @@
+//
+//  String+Extension.swift
+//  BestWish
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import Foundation
+
+extension String {
+    // ✂️ 문자열에서 시작 문자열과 종료 문자열 사이의 내용을 추출
+    func slice(from: String, to: String) -> String? {
+        guard let fromRange = range(of: from)?.upperBound else { return nil }
+        guard let toRange = range(of: to, range: fromRange..<endIndex)?.lowerBound else { return nil }
+        return String(self[fromRange..<toRange])
+    }
+    
+    // 🔍 정규식을 사용하여 첫 번째 일치 문자열을 추출
+    func firstMatch(for regex: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: regex, options: .caseInsensitive) else { return nil }
+        let range = NSRange(location: 0, length: self.utf16.count)
+        if let match = regex.firstMatch(in: self, options: [], range: range),
+           let matchRange = Range(match.range(at: 1), in: self) {
+            return String(self[matchRange])
+        }
+        return nil
+    }
+    
+    func extractNEXTDataJSON() -> String? {
+        guard let startRange = self.range(of: #"<script id="__NEXT_DATA__" type="application/json">"#),
+              let endRange = self.range(of: "</script>", range: startRange.upperBound..<self.endIndex) else {
+            return nil
+        }
+        let jsonString = self[startRange.upperBound..<endRange.lowerBound]
+        return String(jsonString)
+    }
+}

--- a/BestWish/Presentation/Extension/String+Extension.swift
+++ b/BestWish/Presentation/Extension/String+Extension.swift
@@ -34,4 +34,13 @@ extension String {
         let jsonString = self[startRange.upperBound..<endRange.lowerBound]
         return String(jsonString)
     }
+    
+    func extractapplicationLdJson() -> String? {
+        guard let startRange = self.range(of: #"<script id="__NEXT_DATA__" type="application/json">"#),
+              let endRange = self.range(of: "</script>", range: startRange.upperBound..<self.endIndex) else {
+            return nil
+        }
+        let jsonString = self[startRange.upperBound..<endRange.lowerBound]
+        return String(jsonString)
+    }
 }

--- a/BestWish/Presentation/Scene/Dummy/ViewController/DummyViewController.swift
+++ b/BestWish/Presentation/Scene/Dummy/ViewController/DummyViewController.swift
@@ -10,6 +10,7 @@ import RxSwift
 import RxCocoa
 
 class DummyViewController: UIViewController {
+    
     private let dummyView = DummyView()
     private let viewModel: DummyViewModel
     private let disposeBag = DisposeBag()
@@ -38,6 +39,8 @@ class DummyViewController: UIViewController {
 
         bindViewModel()
         viewModel.action.onNext(.viewDidLoad(()))
+        
+        shortcutButtonTapped()
     }
 
     private func bindViewModel() {
@@ -52,5 +55,26 @@ class DummyViewController: UIViewController {
                 print("에러 얼럿 띄우기")
             }.disposed(by: disposeBag)
     }
-}
+    
+    private func shortcutButtonTapped() {
+        dummyView.shortcutButton.rx.tap
+            .withUnretained(self)
+            .bind { owner, _ in
+                guard let sharedDefaults = UserDefaults(suiteName: "group.com.baekyeong.bestwish"),
+                      let urlString = sharedDefaults.string(forKey: "productURL"),
+                      let url = URL(string: urlString) else {
+                    print("❌ 저장된 상품 URL이 없습니다.")
+                    return
+                }
 
+                UIApplication.shared.open(url, options: [:]) { success in
+                    if success {
+                        print("✅ 앱 전환 성공: \(url.absoluteString)")
+                    } else {
+                        print("❌ 앱 전환 실패: \(url.absoluteString)")
+                    }
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/BestWish/Presentation/Scene/Dummy/ViewController/Subview/DummyView.swift
+++ b/BestWish/Presentation/Scene/Dummy/ViewController/Subview/DummyView.swift
@@ -12,6 +12,12 @@ import SnapKit
 final class DummyView: UIView {
     private let titleLabel = UILabel()
     private let priceLabel = UILabel()
+    
+    let shortcutButton = UIButton().then {
+        $0.setTitle("바로가기", for: .normal)
+        $0.setTitleColor(.systemBlue, for: .normal)
+        $0.backgroundColor = .systemGray6
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -59,7 +65,7 @@ private extension DummyView {
 
     // subView 추가 메서드
     func setHierarchy() {
-        self.addSubviews(titleLabel, priceLabel)
+        self.addSubviews(titleLabel, priceLabel, shortcutButton)
     }
 
     // 오토레이이아웃 설정 메서드
@@ -71,6 +77,13 @@ private extension DummyView {
         priceLabel.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(12)
             make.centerX.equalToSuperview()
+        }
+        
+        shortcutButton.snp.makeConstraints { make in
+            make.top.equalTo(priceLabel.snp.bottom).offset(12)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(120)
+            make.height.equalTo(44)
         }
     }
 

--- a/BestWish/Resource/Info.plist
+++ b/BestWish/Resource/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
-	<key>SUPABASE_URL</key>
-	<string>$(SUPABASE_URL)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -19,11 +17,13 @@
 			</array>
 		</dict>
 	</array>
-    <key>NSAppTransportSecurity</key>
-    <dict>
-        <key>NSAllowsArbitraryLoadsInWebContent</key>
-        <true/>
-    </dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+	</dict>
+	<key>SUPABASE_URL</key>
+	<string>$(SUPABASE_URL)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>

--- a/BestWishShareExtension/Base.lproj/MainInterface.storyboard
+++ b/BestWishShareExtension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Share View Controller-->
+        <scene sceneID="ceB-am-kn3">
+            <objects>
+                <viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="1Xd-am-t49"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/BestWishShareExtension/BestWishShareExtension.entitlements
+++ b/BestWishShareExtension/BestWishShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.baekyeong.bestwish</string>
+	</array>
+</dict>
+</plist>

--- a/BestWishShareExtension/Info.plist
+++ b/BestWishShareExtension/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/BestWishShareExtension/ShareViewController.swift
+++ b/BestWishShareExtension/ShareViewController.swift
@@ -36,14 +36,14 @@ class ShareViewController: UIViewController {
     private let productDiscount = UILabel().then {
         $0.textColor = .systemRed
         $0.font = .systemFont(ofSize: 13, weight: .bold)
-        $0.setContentHuggingPriority(.required, for: .horizontal) // ✅ 필수
+        $0.setContentHuggingPriority(.required, for: .horizontal)
     }
     
     private let productPrice = UILabel().then {
         $0.textColor = .label
         $0.font = .systemFont(ofSize: 13, weight: .bold)
-        $0.setContentHuggingPriority(.defaultLow, for: .horizontal) // ✅
-        $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal) // ✅
+        $0.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
     
     private let hStackView = UIStackView().then {
@@ -134,11 +134,16 @@ class ShareViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onSuccess: { [weak self] metadata in
                 guard let self else { return }
+                
                 self.productImage.kf.setImage(with: URL(string: metadata.imageURL ?? ""))
                 self.brandTitle.text = metadata.brandName
                 self.productTitle.text = metadata.productName
                 self.productDiscount.text = "\(metadata.discountRate ?? "0")%"
                 self.productPrice.text = "\(metadata.price ?? "-")원"
+                
+                print("저장되는 상품 url: \(metadata.productURL?.absoluteString)")
+                let sharedDefaults = UserDefaults(suiteName: "group.com.baekyeong.bestwish")
+                sharedDefaults?.setValue(metadata.productURL?.absoluteString, forKey: "productURL")
             }, onFailure: { error in
                 print("❌ Metadata fetch error: \(error.localizedDescription)")
             })

--- a/BestWishShareExtension/ShareViewController.swift
+++ b/BestWishShareExtension/ShareViewController.swift
@@ -132,7 +132,7 @@ class ShareViewController: UIViewController {
         ShareExtensionService.shared
             .fetchPlatformMetadata(from: text)
             .observe(on: MainScheduler.instance)
-            .subscribe(onSuccess: { [weak self] metadata in
+            .subscribe(onSuccess: { [weak self] originalUrl, metadata in
                 guard let self else { return }
                 
                 self.productImage.kf.setImage(with: URL(string: metadata.imageURL ?? ""))

--- a/BestWishShareExtension/ShareViewController.swift
+++ b/BestWishShareExtension/ShareViewController.swift
@@ -1,0 +1,147 @@
+//
+//  ShareViewController.swift
+//  BestWishShareExtension
+//
+//  Created by 백래훈 on 6/9/25.
+//
+
+import UIKit
+import Social
+
+import Kingfisher
+import RxSwift
+import SnapKit
+import Then
+
+class ShareViewController: UIViewController {
+
+    private let productImage = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.layer.borderColor = UIColor.systemGray6.cgColor
+        $0.layer.borderWidth = 0.5
+        $0.clipsToBounds = true
+    }
+    
+    private let brandTitle = UILabel().then {
+        $0.textColor = .label
+        $0.font = .systemFont(ofSize: 11, weight: .bold)
+    }
+    
+    private let productTitle = UILabel().then {
+        $0.textColor = .label
+        $0.font = .systemFont(ofSize: 14, weight: .regular)
+        $0.numberOfLines = 2
+    }
+    
+    private let productDiscount = UILabel().then {
+        $0.textColor = .systemRed
+        $0.font = .systemFont(ofSize: 13, weight: .bold)
+        $0.setContentHuggingPriority(.required, for: .horizontal) // ✅ 필수
+    }
+    
+    private let productPrice = UILabel().then {
+        $0.textColor = .label
+        $0.font = .systemFont(ofSize: 13, weight: .bold)
+        $0.setContentHuggingPriority(.defaultLow, for: .horizontal) // ✅
+        $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal) // ✅
+    }
+    
+    private let hStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 4
+        $0.alignment = .leading
+        $0.distribution = .fill
+    }
+    
+    private let vStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 4
+    }
+    
+    let disposeBag = DisposeBag()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureView()
+        setConstraints()
+        
+        extractSharedContent()
+    }
+    
+    private func configureView() {
+        self.view.backgroundColor = .systemBackground
+        
+        [productImage, vStackView].forEach {
+            self.view.addSubview($0)
+        }
+        
+        [brandTitle, productTitle, hStackView].forEach {
+            self.vStackView.addArrangedSubview($0)
+        }
+        
+        [productDiscount, productPrice].forEach {
+            self.hStackView.addArrangedSubview($0)
+        }
+        
+    }
+    
+    private func setConstraints() {
+        productImage.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            $0.centerX.equalToSuperview()
+            $0.size.equalTo(150)
+        }
+        
+        vStackView.snp.makeConstraints {
+            $0.top.equalTo(productImage.snp.bottom).offset(4)
+            $0.centerX.equalTo(productImage.snp.centerX)
+            $0.width.equalTo(productImage.snp.width)
+        }
+    }
+    
+    // MARK: - 아래의 메서드들은 ViewModel로 이전
+    // 📥 공유된 콘텐츠를 추출하여 각 provider에 대해 처리
+    private func extractSharedContent() {
+        guard let extensionItems = extensionContext?.inputItems as? [NSExtensionItem] else { return }
+
+        for item in extensionItems {
+            guard let attachments = item.attachments else { continue }
+            for provider in attachments {
+                handleSharedItem(from: provider)
+            }
+        }
+    }
+
+    // 🔍 provider의 타입에 따라 URL 또는 텍스트로 처리 분기
+    private func handleSharedItem(from provider: NSItemProvider) {
+        if provider.hasItemConformingToTypeIdentifier("public.url") {
+            provider.loadItem(forTypeIdentifier: "public.url", options: nil) { [weak self] item, _ in
+                guard let self, let url = item as? URL else { return }
+                self.handleSharedText(url.absoluteString)
+            }
+        } else if provider.hasItemConformingToTypeIdentifier("public.text") {
+            provider.loadItem(forTypeIdentifier: "public.text", options: nil) { [weak self] item, _ in
+                guard let self, let text = item as? String else { return }
+                self.handleSharedText(text)
+            }
+        }
+    }
+    
+    private func handleSharedText(_ text: String) {
+        ShareExtensionService.shared
+            .fetchPlatformMetadata(from: text)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] metadata in
+                guard let self else { return }
+                self.productImage.kf.setImage(with: URL(string: metadata.imageURL ?? ""))
+                self.brandTitle.text = metadata.brandName
+                self.productTitle.text = metadata.productName
+                self.productDiscount.text = "\(metadata.discountRate ?? "0")%"
+                self.productPrice.text = "\(metadata.price ?? "-")원"
+            }, onFailure: { error in
+                print("❌ Metadata fetch error: \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+    }
+}


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 앱 외부(예: 브라우저, 쇼핑 앱 등)에서 콘텐츠를 공유할 수 있도록 Share Extension 기능 도입
 - 별도의 Share Extension 타겟 추가 (BestWishShareExtension)
 - 프로젝트 타겟 내에서 데이터를 처리할 수 있는 Service 클래스 구성 예정 (Data Layer/Network/Service/ShareExtension 내 위치)

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- BestWishShareExtension Target에서 사용될 파일들은 모두 Target Membership에서 BestWishShareExtension을 체크해줘야 합니다.
- 현재 무신사, 지그재그, 에이블리 3개의 쇼핑 플랫폼 상품 정보 저장과 딥링크(앱 바로가기) 기능까지 구현하였습니다.
- 추후 타 쇼핑 플랫폼까지 추가할 예정입니다. (ex. 브랜디, 4910, 크림, 29cm 등)

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| 실행 기기 | 스크린샷(또는 GIF) | 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: | :-------------: | :----------: |
| **무신사 상품**</br>iPhone 13 Pro | <img src = "https://github.com/user-attachments/assets/467543f2-dfc9-446b-87bb-0d908cd6d66e" width ="250"> | **앱 전환(무신사)**</br>iPhone 13 Pro | <img src = "https://github.com/user-attachments/assets/f7e8df39-ff1c-462f-8783-cf83c4e04b1c" width ="250"> |
| **에이블리 상품**</br>iPhone 13 Pro | <img src = "https://github.com/user-attachments/assets/6761e923-4509-4c47-8c37-721e4da951f7" width ="250"> | **앱 전환(에이블리)**</br>iPhone 13 Pro | <img src = "https://github.com/user-attachments/assets/dc918356-d1a5-4bdc-97c9-e962b3c99a61" width ="250"> |
| **지그재그 상품**</br>iPhone 13 Pro | <img src = "https://github.com/user-attachments/assets/016e6e60-a5fd-4dea-941c-1758466f2bef" width ="250"> | **앱 전환(지그재그)**</br>iPhone 13 Pro | <img src = "https://github.com/user-attachments/assets/0f75d61a-8147-407e-9717-bf04b1a36bb0" width ="250"> |

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #17 
