### PR TITLE
fix: #80 - 카메라 비동기 경고 이슈 해결

### DIFF
--- a/BestWish/Presentation/Scene/Camera/ViewController/CameraViewController.swift
+++ b/BestWish/Presentation/Scene/Camera/ViewController/CameraViewController.swift
@@ -35,9 +35,11 @@ final class CameraViewController: UIViewController {
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .notDetermined:                                                        // 처음 실행 시, 사용자에게 권한 요청
             AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in     // 요청 실패 시 아직 어떠한 이벤트도 넣지 않은 상태
-                guard granted else { return }
-                self?.setUpCamera()
-                self?.cameraView.showToast()
+                guard granted, let self else { return }
+                DispatchQueue.main.async {
+                    self.setUpCamera()
+                    self.cameraView.showToast()
+                }
             }
         case .restricted, .denied: break                                            // 사용 제한 상태
         case .authorized:


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 카메라 비동기 경고 이슈 해결

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
```checkCameraPermissions() ``` 내부 requestAccess()가 비동기 메서드라 메인스레드로 바꿔줬습니다!
![image](https://github.com/user-attachments/assets/7c3642c8-8e1e-47be-baf5-9077b32ab206)

```swift
   /// 카메라 권한 확인 로직 메서드
    private func checkCameraPermissions() {
        switch AVCaptureDevice.authorizationStatus(for: .video) {
        case .notDetermined:                                                        // 처음 실행 시, 사용자에게 권한 요청
            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in     // 요청 실패 시 아직 어떠한 이벤트도 넣지 않은 상태
                guard granted, let self else { return }
                DispatchQueue.main.async {
                    self.setUpCamera()
                    self.cameraView.showToast()
                }
            }
        case .restricted, .denied: break                                            // 사용 제한 상태
        case .authorized:
            setUpCamera()
            cameraView.showToast()
        @unknown default: break                                                     // 이미 허용된 상태
        }
    }
```

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #80 
