### PR TITLE
Refactor/#87 onboarding view model

### DIFF
--- a/BestWish/Presentation/Display/UserInfoDisplay.swift
+++ b/BestWish/Presentation/Display/UserInfoDisplay.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserInfoDisplay {
+struct UserInfoDisplay: Equatable {
     var profileImageCode: Int
     var profileImageName: String {
         ProfileType(rawValue: profileImageCode)?.name ?? ProfileType.profileA.name

--- a/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewController/MyPageViewController.swift
+++ b/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewController/MyPageViewController.swift
@@ -76,10 +76,10 @@ final class MyPageViewController: UIViewController {
                 case .question:
                     owner.sendQuestion()
                 case .termsOfUse:
-                    let nextVC = PDFViewController(type: .service)
+                    let nextVC = PDFViewController(type: .termsOfUse)
                     self.present(nextVC, animated: true)
                 case .privacyPolicy:
-                    let nextVC = PDFViewController(type: .privacy)
+                    let nextVC = PDFViewController(type: .privacyPolicy)
                     self.present(nextVC, animated: true)
                 case .logout:
                     AlertBuilder(baseViewController: self, type: .logout) {

--- a/BestWish/Presentation/Scene/MyPage/ProfileUpdate/ProfileUpdateViewModel.swift
+++ b/BestWish/Presentation/Scene/MyPage/ProfileUpdate/ProfileUpdateViewModel.swift
@@ -31,7 +31,7 @@ final class ProfileUpdateViewModel: ViewModel {
     var action: AnyObserver<Action> { _action.asObserver() }
 
     private let _userInfo = BehaviorRelay<UserInfoDisplay?>(value: nil)
-    private let _isVaildNickname = BehaviorRelay<Bool>(value: true)
+    private let _isValidNickname = BehaviorRelay<Bool>(value: true)
     private let _completedSave = PublishSubject<Void>()
     private let _error = PublishSubject<AppError>()
     let state: State
@@ -40,7 +40,7 @@ final class ProfileUpdateViewModel: ViewModel {
         self.useCase = useCase
         state = State(
             userInfo: _userInfo.asObservable(),
-            isValidNickname: _isVaildNickname.asObservable(),
+            isValidNickname: _isValidNickname.asObservable(),
             completedSave: _completedSave.asObservable(),
             error: _error.asObservable()
         )
@@ -83,7 +83,7 @@ final class ProfileUpdateViewModel: ViewModel {
 
     private func updateNickname(to nickname: String) {
         let isValid = useCase.isValidNickname(nickname)
-        _isVaildNickname.accept(isValid)
+        _isValidNickname.accept(isValid)
 
         if isValid {
             var userInfo = _userInfo.value

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/Component/BirthSelectionView.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/Component/BirthSelectionView.swift
@@ -6,14 +6,16 @@
 //
 
 import UIKit
-import SnapKit
-import Then
+import RxSwift
+import RxCocoa
 
 final class BirthSelectionView: UIView {
 
     private let rootVStackView = VerticalStackView(spacing: 8)
     private let birthLabel = InfoLabel(title: "생년월일")
     let dateButton = UIButton()
+
+    private let disposeBag = DisposeBag()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -35,6 +37,7 @@ private extension BirthSelectionView {
         setAttributes()
         setHierarchy()
         setConstraints()
+        setBindings()
     }
 
     func setAttributes() {
@@ -75,6 +78,14 @@ private extension BirthSelectionView {
         dateButton.snp.makeConstraints {
             $0.height.equalTo(48)
         }
+    }
+
+    func setBindings() {
+        dateButton.rx.tap
+            .subscribe(with: self) { owner, _ in
+            owner.dateButton.layer.borderColor = UIColor.primary300?.cgColor
+        }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/Component/IntroTextStackView.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/Component/IntroTextStackView.swift
@@ -6,8 +6,6 @@
 //
 
 import UIKit
-import SnapKit
-import Then
 
 final class IntroTextStackView: UIView {
 

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/Component/NicknameInputView.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/Component/NicknameInputView.swift
@@ -6,8 +6,6 @@
 //
 
 import UIKit
-import SnapKit
-import Then
 import RxSwift
 import RxCocoa
 

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/Component/OnboardingHeaderView.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/Component/OnboardingHeaderView.swift
@@ -6,8 +6,6 @@
 //
 
 import UIKit
-import SnapKit
-import Then
 
 final class OnboardingHeaderView: UIView {
 

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/Component/PageInfoLabel.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/Component/PageInfoLabel.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Then
 
 final class PageInfoView: UILabel {
 

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/Component/RadioButton.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/Component/RadioButton.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Then
 
 final class RadioButton: UIButton {
 

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
@@ -128,7 +128,6 @@ private extension OnboardingViewController {
         // 생일 바인딩
         firstView.birthSelection.dateButton.rx.tap
             .subscribe(with: self) { owner, _ in
-            owner.firstView.birthSelection.dateButton.layer.borderColor = UIColor.primary300?.cgColor
             let sheetVC = DatePickerBottomSheetViewController()
             sheetVC.presentationController?.delegate = self
             // 선택된 날짜 콜백

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
@@ -33,6 +33,7 @@ final class OnboardingViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModel.action.onNext(.viewDidAppear)
+        viewModel.action.onNext(.createUserInfo)
     }
 
 
@@ -55,13 +56,7 @@ final class OnboardingViewController: UIViewController {
     }
 
     private func bindViewModel() {
-        viewModel.state.userInfo
-            .observe(on: MainScheduler.instance)
-            .subscribe(with: self) { owner, userInfo in
-            owner.firstView.birthSelection.configure(title: userInfo.birthString)
-        }
-            .disposed(by: disposeBag)
-
+        /// 온보딩 순서 바인딩
         viewModel.state.currentPage
             .observe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, page in
@@ -69,36 +64,26 @@ final class OnboardingViewController: UIViewController {
         }
             .disposed(by: disposeBag)
 
+        /// 온보딩 1 바인딩
+        /// - firstView.configure(생일 선택, 버튼 활성화)
+        /// 온보딩 2 바인딩
+        /// - 프로필 사진 바인딩
         viewModel.state.userInfo
-            .bind(with: self) { owner, userInput in
-            owner.secondView.configure(input: userInput)
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, userInfo in
+            owner.firstView.configure(with: userInfo)
+            owner.secondView.configure(imageName: userInfo?.profileImageName)
         }
             .disposed(by: disposeBag)
 
-        viewModel.state.userInfo
-            .map { input in
-            return input.gender != nil && input.birth != nil
-        }
-            .distinctUntilChanged()
+        /// 닉네임 유효성 검사 바인딩
+        /// secondView.configure(textField,caution 색상, 버튼 활성화)
+        viewModel.state.isValidNickname
             .observe(on: MainScheduler.instance)
-            .subscribe(with: self) { owner, isValid in
-            owner.firstView.nextPageButton.isEnabled = isValid
-            owner.firstView.configure(isValid)
-        }
-            .disposed(by: disposeBag)
-
-        Observable
-            .combineLatest(
-            viewModel.state.userInfo.map { $0.nickname != nil },
-            viewModel.state.isValidNickname
-        ) { hasNick, isValid in
-            hasNick && isValid
-        }
-            .distinctUntilChanged()
-            .observe(on: MainScheduler.instance)
-            .subscribe(with: self) { owner, enabled in
-            owner.secondView.completeButton.isEnabled = enabled
-            owner.secondView.configure(enabled)
+            .bind(with: self) { owner, isValid in
+            guard let isValid else { return }
+            owner.secondView.configure(isValidNickname: isValid)
         }
             .disposed(by: disposeBag)
     }
@@ -132,20 +117,19 @@ private extension OnboardingViewController {
             sheetVC.presentationController?.delegate = self
             // 선택된 날짜 콜백
             sheetVC.onDateSelected = { date in
-                self.dismiss(animated: true) {
-                    self.firstView.birthSelection.dateButton.layer.borderColor = UIColor.gray200?.cgColor
+                owner.dismiss(animated: true) {
+                    owner.firstView.configure()
                 }
                 owner.viewModel.action.onNext(.selectedBirth(date))
             }
 
             sheetVC.onCancel = {
-                self.dismiss(animated: false) {
-                    self.firstView.birthSelection.dateButton.layer.borderColor = UIColor.gray200?.cgColor
+                owner.dismiss(animated: false) {
+                    owner.firstView.configure()
                 }
             }
-
             sheetVC.presentDatePickerSheet()
-            self.present(sheetVC, animated: true)
+            owner.present(sheetVC, animated: true)
         }
             .disposed(by: disposeBag)
     }
@@ -154,58 +138,28 @@ private extension OnboardingViewController {
         // 프로필 사진 바인딩
         let tapGesture = UITapGestureRecognizer()
         secondView.profileImageView.addGestureRecognizer(tapGesture)
-
         tapGesture.rx.event
             .withLatestFrom(viewModel.state.userInfo)
             .bind(with: self) { owner, userInfo in
+            guard let userInfo else { return }
             let profileSheetVC = ProfileSheetViewController(selectedIndex: userInfo.profileImageCode)
             profileSheetVC.presentProfileSheet()
             profileSheetVC.onComplete = { [weak self] selectedIndex in
                 self?.viewModel.action.onNext(.selectedProfileIndex(selectedIndex))
             }
             owner.present(profileSheetVC, animated: true)
-        }.disposed(by: disposeBag)
-
-        // 닉네임 바인딩
-        /// 1) 텍스트 스트림
-        let textStream = secondView.nicknameVStackView.textField.rx.text.orEmpty
-            .skip(2)
-
-        /// 2) 텍스트+유효성 스트림
-        let validationStream: Observable<(String, Bool)> = textStream
-            .map { text in
-            let isValid = NSPredicate(
-                format: "SELF MATCHES %@",
-                "^[가-힣A-Za-z0-9]{2,10}$"
-            ).evaluate(with: text)
-            return (text, isValid)
-        }
-            .distinctUntilChanged { prev, curr in
-            prev.0 == curr.0 && prev.1 == curr.1
-        }
-
-        /// 3) 구독
-        validationStream
-            .observe(on: MainScheduler.instance)
-            .subscribe(with: self) { owner, data in
-            let (text, isValid) = data
-            owner.secondView.nicknameVStackView.textField.layer.borderColor =
-                isValid ? UIColor.primary300?.cgColor // 허용 값
-            : UIColor.red0?.cgColor // 불허 값
-
-            owner.secondView.nicknameVStackView.cautionLabel.textColor =
-                isValid ? .gray200 : .red0
-
-            // 닉네임 유효성 검사 성공시 전달
-            owner.viewModel.action.onNext(.inputNicknameValid(isValid))
-
-            if isValid {
-                // 닉네임 유효성 검사 성공시 닉네임 전달
-                owner.viewModel.action.onNext(.inputNickname(text))
-            }
         }
             .disposed(by: disposeBag)
 
+        // 닉네임 바인딩
+        secondView.nicknameVStackView.textField.rx.text.orEmpty
+            .skip(2)
+            .distinctUntilChanged()
+            .debounce(.microseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self) { owner, nickname in
+            owner.viewModel.action.onNext(.inputNickname(nickname))
+        }
+            .disposed(by: disposeBag)
     }
 
     func bindPageButton() {
@@ -225,6 +179,7 @@ private extension OnboardingViewController {
         secondView.completeButton.rx.tap
             .withLatestFrom(viewModel.state.userInfo)
             .subscribe(with: self) { owner, userInfoDisplay in
+            guard let userInfoDisplay else { return }
             owner.viewModel.action.onNext(.uploadUserInfo(userInfoDisplay))
         }
             .disposed(by: disposeBag)

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/Subview/OnboardingFirstView.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/Subview/OnboardingFirstView.swift
@@ -20,7 +20,6 @@ final class OnboardingFirstView: UIView {
     private let buttonVStackView = VerticalStackView()
     let nextPageButton = AppButton(type: .next)
 
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         setView()
@@ -33,6 +32,19 @@ final class OnboardingFirstView: UIView {
 
     func configure(_ isValid: Bool) {
         nextPageButton.isEnabled = isValid
+    }
+    private func canNext(_ isValid: Bool) {
+        nextPageButton.isEnabled = isValid
+    }
+
+    func configure(with userInfo: UserInfoDisplay?) {
+        let isValid = userInfo?.gender != nil && userInfo?.birth != nil
+        canNext(isValid)
+        birthSelection.configure(title: userInfo?.birthString)
+    }
+
+    func configure() {
+        birthSelection.dateButton.layer.borderColor = UIColor.gray200?.cgColor
     }
 
 }
@@ -97,4 +109,3 @@ private extension OnboardingFirstView {
         }
     }
 }
-

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/Subview/OnboardingSecondView.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/Subview/OnboardingSecondView.swift
@@ -11,8 +11,8 @@ import Then
 
 final class OnboardingSecondView: UIView {
     private let headerView = OnboardingHeaderView(current: 2, total: 2,
-                                              title: OnboardingText.secondTitle.value,
-                                              desc: OnboardingText.secondDesc.value)
+                                                  title: OnboardingText.secondTitle.value,
+                                                  desc: OnboardingText.secondDesc.value)
     private let profileContainer = UIView()
     let profileImageView = UIImageView()
 
@@ -32,13 +32,19 @@ final class OnboardingSecondView: UIView {
         fatalError()
     }
 
-    func configure(input: UserInfoDisplay) {
-        profileImageView.image = UIImage(named: input.profileImageName)?.resize(to: CGSize(width: CGFloat(152).fitHeight, height: CGFloat(152).fitHeight))
-
+    func configure(imageName: String?) {
+        guard let imageName else { return }
+        profileImageView.image = UIImage(named: imageName)?.resize(to: CGSize(width: CGFloat(152).fitHeight, height: CGFloat(152).fitHeight))
     }
 
-    func configure(_ isValid: Bool) {
-        completeButton.isEnabled = isValid
+    func configure(isValidNickname: Bool) {
+        // 버튼 활성화
+        completeButton.isEnabled = isValidNickname
+
+        nicknameVStackView.textField.layer.borderColor =
+        isValidNickname ? UIColor.primary300?.cgColor : UIColor.red0?.cgColor
+
+        nicknameVStackView.cautionLabel.textColor = isValidNickname ? .gray200 : .red0
     }
 
 }
@@ -77,7 +83,7 @@ private extension OnboardingSecondView {
 
     func setHierarchy() {
 
-        self.addSubviews(headerView,profileImageView, nickName2ButtonStackView)
+        self.addSubviews(headerView, profileImageView, nickName2ButtonStackView)
         nickName2ButtonStackView.addArrangedSubviews(nicknameVStackView, buttonHStackView)
         buttonHStackView.addArrangedSubviews(prevButton, completeButton)
     }

--- a/BestWish/Presentation/Scene/PDFViewer/PDFViewController.swift
+++ b/BestWish/Presentation/Scene/PDFViewer/PDFViewController.swift
@@ -11,15 +11,15 @@ import Then
 import PDFKit
 
 enum PDFType {
-    case privacy
-    case service
+    case privacyPolicy // 개인정보 처리 방침
+    case termsOfUse // 서비스 이용 약관
 
     var url: URL? {
         switch self {
-        case .privacy:
+        case .privacyPolicy:
             return Bundle.main.url(forResource: "privacyPolicy", withExtension: "pdf")
-        case .service:
-            return Bundle.main.url(forResource: "servicePolicy", withExtension: "pdf")
+        case .termsOfUse:
+            return Bundle.main.url(forResource: "termsOfUse", withExtension: "pdf")
         }
     }
 }

--- a/BestWish/Presentation/Scene/Policy/PolicyViewController.swift
+++ b/BestWish/Presentation/Scene/Policy/PolicyViewController.swift
@@ -63,7 +63,7 @@ final class PolicyViewController: UIViewController {
     private func bindPDFButton() {
         policyView.privacyViewButton.rx.tap
             .subscribe(with: self) { owner, _ in
-            let pdfVC = PDFViewController(type: .privacy)
+            let pdfVC = PDFViewController(type: .privacyPolicy)
             if let sheet = pdfVC.sheetPresentationController {
                 sheet.detents = [.large()]
                 sheet.prefersGrabberVisible = false
@@ -74,7 +74,7 @@ final class PolicyViewController: UIViewController {
 
         policyView.serviceViewButton.rx.tap
             .subscribe(with: self) { owner, _ in
-            let pdfVC = PDFViewController(type: .service)
+            let pdfVC = PDFViewController(type: .termsOfUse)
             if let sheet = pdfVC.sheetPresentationController {
                 sheet.detents = [.large()]
                 sheet.prefersGrabberVisible = false

--- a/BestWish/Presentation/Scene/Policy/Subview/PolicyBottomSheetView.swift
+++ b/BestWish/Presentation/Scene/Policy/Subview/PolicyBottomSheetView.swift
@@ -12,18 +12,16 @@ import Then
 final class PolicyBottomSheetView: UIView {
     private let infoStackView: IntroTextStackView
     private let separator = UIView()
-    /// 모두 동의합니다
+
     private let selectAllHStack = HorizontalStackView(spacing: 8)
     let selectAllCheckButton = UIButton()
     private let selectAllLabel = UILabel()
 
-    /// 개인정보
     private let privacyHStack = HorizontalStackView(spacing: 8)
     let privacyCheckButton = UIButton()
     private let privacyLabel = UILabel()
     let privacyViewButton = UIButton()
 
-    /// 이용약관
     private let serviceHStack = HorizontalStackView(spacing: 8)
     let serviceCheckButton = UIButton()
     private let serviceLabel = UILabel()
@@ -31,7 +29,6 @@ final class PolicyBottomSheetView: UIView {
 
     let completeButton = AppButton(type: .complete)
 
-    // MARK: - Init
     init(title: String, desc: String) {
         self.infoStackView = IntroTextStackView(title: title, desc: desc)
         super.init(frame: .zero)


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 정책 변수명 수정 
 ```
   - case privacy
   - case service
   + case privacyPolicy // 개인정보 처리 방침
   + case termsOfUse // 서비스 이용 약관
```
 - 생년월일설정 버튼 선택에 대해 view에서 처리할 수 있는 rx.tap.event와 viewModel로 넘겨야하는 rx.tap.event 분리
 - OnboardingViewModel - ViewController 코드 리팩토링

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
ProfileUpdateViewModel에 있는 변수명 오타 수정했습니다
## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone - | <img src = "" width ="250"> |

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #87 
