### PR TITLE
Fix/#97 onboarding memory leak

### DIFF
--- a/BestWish/Data/Network/Manager/SocialLogin/Apple/AppleLogin.swift
+++ b/BestWish/Data/Network/Manager/SocialLogin/Apple/AppleLogin.swift
@@ -195,8 +195,3 @@ extension SupabaseOAuthManager: ASAuthorizationControllerDelegate {
     }
 }
 
-extension SupabaseOAuthManager: ASAuthorizationControllerPresentationContextProviding {
-    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return presentationWindow ?? UIWindow()
-    }
-}

--- a/BestWish/Data/Network/Manager/SocialLogin/Kakao/KakaoLogin.swift
+++ b/BestWish/Data/Network/Manager/SocialLogin/Kakao/KakaoLogin.swift
@@ -16,15 +16,21 @@ extension SupabaseOAuthManager {
             return nil
         }
         do {
-            let session = try await client.auth.signInWithOAuth(provider: Provider.kakao, redirectTo: redirectURL) { session in
+            let session = try await client.auth.signInWithOAuth(provider: Provider.kakao, redirectTo: redirectURL) { [weak self] session in
+                guard let self else { return }
+
+                self.kakaoAuthSession = session
+                session.presentationContextProvider = self
                 session.prefersEphemeralWebBrowserSession = true
             }
+            kakaoAuthSession = nil
             return session
         } catch {
+            kakaoAuthSession?.cancel()
+            kakaoAuthSession = nil
             print("error: \(error.localizedDescription)")
+            return nil
         }
-
-        return nil
     }
 
     func unlinkKakaoAccount(_ token: String) async throws {

--- a/BestWish/Data/Network/Manager/SupabaseOAuthManager.swift
+++ b/BestWish/Data/Network/Manager/SupabaseOAuthManager.swift
@@ -16,9 +16,9 @@ final class SupabaseOAuthManager: NSObject {
 
     // actor KeyChainManager 인스턴스
     public let keychain = KeyChainManager()
-
     public var continuation: CheckedContinuation<(String, Supabase.Session), Error>?
     public weak var presentationWindow: UIWindow?
+    public var kakaoAuthSession: ASWebAuthenticationSession?
     public var currentNonce: String?
 
     let client = SupabaseClient(
@@ -190,5 +190,14 @@ extension SupabaseOAuthManager {
     enum SocialType {
         case kakao
         case apple
+    }
+}
+
+extension SupabaseOAuthManager: ASWebAuthenticationPresentationContextProviding, ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return presentationWindow ?? UIWindow()
+    }
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return presentationWindow ?? UIWindow()
     }
 }

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
@@ -60,7 +60,7 @@ final class OnboardingViewController: UIViewController {
         viewModel.state.currentPage
             .observe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, page in
-            self.view = owner.onboardingViews[page]
+            owner.view = owner.onboardingViews[page]
         }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
- OnboardingViewController와 하위 컴포넌트 들에서 발생했던 메모리 누수 해결
- 소셜 로그인에서 발생했던 메모리 누수 해결

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
OnboardingViewController와 하위 컴포넌트 들에서 발생했던 메모리 누수는 휴먼 에러 였던걸로 판결
소셜 로그인에서 발생했던 메모리 누수 해결은
![image](https://github.com/user-attachments/assets/f6854af5-8e0d-4aab-92a5-be9fed3efa1f)
ouath를 관리하는 두 기능들이 서로 참조 관계를 형성해 발생했던 것이었습니다.
카카오톡으로 로그인을 할경우 카카오톡 로그인 -> (여기서 메모리 누수 발생) 카카오톡 자체 필수/선택 동의항목 제출 페이지가 등장하게 되는데 두번째 화면에서 두 세션(sfauthenticationsession, aswebauthenticationsession)에 메모리 누수가 발생

해당 문제를 카카오톡 로그인하는 session을 따로 분리 시킴!


gpt 설명
지금 메모리 그래프를 보면 ASWebAuthenticationSession 인스턴스가 내부 _referenceToSelf 프로퍼티로 자기 자신을 강하게 참조하고, _authenticationSession 프로퍼티로 또 SFAuthenticationSession(레거시) 인스턴스를 참조하고 있네요.
이 두 개가 서로를 끊어주지 않으면 ARC로도 해제되지 않아서 “유령(ghost) 세션”이 남아 있는 것처럼 보입니다.
Apple 내부 구현상, ASWebAuthenticationSession이 스스로를 참조하는 _referenceToSelf를 갖고 있어서 사용자가 명시적으로 세션을 종료(취소)하거나, 해당 객체에 대한 strong reference 를 모두 끊기 전까지는 메모리에서 해제되지 않습니다.
즉, 우리가 프로퍼티에 할당해 둔 session 변수를 nil로 만들거나, cancel()을 호출하지 않으면 내부에서 계속 살아있게 됩니다.


## 📸 스크린샷
<img width="1997" alt="image" src="https://github.com/user-attachments/assets/1cc433d5-084c-47fa-9adf-4da43608d5d8" />
<img width="868" alt="image" src="https://github.com/user-attachments/assets/430eb847-78cd-451b-82e6-30817f57b627" />


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #97
