### PR TITLE
Refactor/#135 v1.0.1 yimkeul

### DIFF
--- a/BestWish/App/SceneDelegate.swift
+++ b/BestWish/App/SceneDelegate.swift
@@ -46,9 +46,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let repository = DIContainer.shared.makeAccountRepository()
 
         Task {
-            let hasToken = await repository.checkTokenState()
-            if hasToken {
-                let didOnboarding = await repository.checkOnboardingState()
+            let isAliveSession = await repository.checkSupabaseSession()
+            if isAliveSession {
+                let didOnboarding = try await repository.checkOnboardingState()
                 if didOnboarding {
                     self.showMainView()
                 } else {

--- a/BestWish/Data/KeyChain/Error/KeyChainError.swift
+++ b/BestWish/Data/KeyChain/Error/KeyChainError.swift
@@ -9,20 +9,20 @@ import Foundation
 
 /// 키체인 에러 종류
 enum KeyChainError: AppErrorProtocol {
-    case readError(String)
+    case readError
     case saveError
     case deleteError
 }
 
 extension KeyChainError {
     var errorDescription: String? {
-        "개인정보 오류가 발생했습니다"
+        "보안 오류가 발생했습니다"
     }
 
     var debugDescription: String {
         switch self {
-        case let .readError(detail):
-            "KeyChain Read Error : \(detail)"
+        case .readError:
+            "KeyChain Read Error"
         case .saveError:
             "KeyChain Save Error"
         case .deleteError:

--- a/BestWish/Data/Network/Error/AuthError.swift
+++ b/BestWish/Data/Network/Error/AuthError.swift
@@ -18,8 +18,9 @@ enum AuthError: AppErrorProtocol {
     case supabaseRequestSecretCodeNil
     case withdrawFailed(Error)
     case appleDidCompleteFailed
-    case setSessionFailed(Error)
+    case supabaseSetSessionFailed(Error)
     case missProvider
+    case supabaseRequestRoleFailed(Error)
 }
 
 // MARK: - AuthError 케이스 별 텍스트
@@ -30,28 +31,35 @@ extension AuthError {
 
     var debugDescription: String {
         switch self {
+            /// 카카오
         case let .kakaoSignInFailed(error):
             "Kakao SignIn Error: \(error.localizedDescription)"
+
+            /// 애플
         case let .appleSignInFailed(error):
             "Auth Error: \(error.localizedDescription)"
-        case let .signOutFailed(error):
-            "SignOut Error: \(error.localizedDescription)"
         case let .appleRequestAccessTokenFailed(error):
             "Apple Access Token Error: \(error.localizedDescription)"
+        case .appleDidCompleteFailed:
+            "Apple DidCompleted Failed"
         case let .encodeParsingTokenError(field):
             "Encoding Parsing Access Token Error : \(field)"
+
+            /// Supabase
+        case let .supabaseRequestRoleFailed(error):
+            "Supabase Request Role Failed : \(error.localizedDescription)"
         case let .supabaseRequestSecretCodeFailed(error):
             "Supabase Request Client Secret Error : \(error.localizedDescription)"
         case .supabaseRequestSecretCodeNil:
             "Supabase Request Client Secret Return Nil"
-        case let .withdrawFailed(error):
-            "Withdraw Error: \(error.localizedDescription)"
-        case .appleDidCompleteFailed:
-            "Apple DidCompleted Failed"
-        case let .setSessionFailed(error):
+        case let .supabaseSetSessionFailed(error):
             "Supabase Set Session Failed : \(error.localizedDescription)"
         case .missProvider:
             "Missing Provider"
+        case let .signOutFailed(error):
+            "SignOut Error: \(error.localizedDescription)"
+        case let .withdrawFailed(error):
+            "Withdraw Error: \(error.localizedDescription)"
         }
     }
 }

--- a/BestWish/Data/Network/Error/AuthError.swift
+++ b/BestWish/Data/Network/Error/AuthError.swift
@@ -9,8 +9,7 @@ import Foundation
 
 /// 사용자 인증 정보 관련 에러 모음
 enum AuthError: AppErrorProtocol {
-    case kakaoSignInFailed(Error)
-    case appleSignInFailed(Error)
+    case signInFailed(SocialType, Error)
     case signOutFailed(Error)
     case appleRequestAccessTokenFailed(Error)
     case encodeParsingTokenError(String)
@@ -31,13 +30,14 @@ extension AuthError {
 
     var debugDescription: String {
         switch self {
-            /// 카카오
-        case let .kakaoSignInFailed(error):
-            "Kakao SignIn Error: \(error.localizedDescription)"
+        case let .signInFailed(socialType, error):
+            "\(socialType) SignIn Error: \(error.localizedDescription)"
+        case let .signOutFailed(error):
+            "SignOut Error: \(error.localizedDescription)"
+        case let .withdrawFailed(error):
+            "Withdraw Error: \(error.localizedDescription)"
 
             /// 애플
-        case let .appleSignInFailed(error):
-            "Auth Error: \(error.localizedDescription)"
         case let .appleRequestAccessTokenFailed(error):
             "Apple Access Token Error: \(error.localizedDescription)"
         case .appleDidCompleteFailed:
@@ -56,10 +56,7 @@ extension AuthError {
             "Supabase Set Session Failed : \(error.localizedDescription)"
         case .missProvider:
             "Missing Provider"
-        case let .signOutFailed(error):
-            "SignOut Error: \(error.localizedDescription)"
-        case let .withdrawFailed(error):
-            "Withdraw Error: \(error.localizedDescription)"
+
         }
     }
 }

--- a/BestWish/Data/Network/Manager/SocialLogin/Apple/AppleLogin.swift
+++ b/BestWish/Data/Network/Manager/SocialLogin/Apple/AppleLogin.swift
@@ -41,7 +41,7 @@ extension SupabaseOAuthManager {
         guard let token = keyChain.read(token: .init(service: .access)) else {
             NSLog("ERROR : Supabase AccessToken Read Fail")
             // FIXME: - 현재 아래 error는 Alert으로 안나오는 현상이 있음.
-            throw KeyChainError.readError("Service : Supabse AccessToken")
+            throw KeyChainError.readError
         }
 
         do {

--- a/BestWish/Data/Network/Manager/SocialLogin/Apple/AppleLogin.swift
+++ b/BestWish/Data/Network/Manager/SocialLogin/Apple/AppleLogin.swift
@@ -220,7 +220,7 @@ extension SupabaseOAuthManager: ASAuthorizationControllerDelegate {
                 continuation.resume(returning: (authCodeString, session))
             } catch {
                 NSLog("Supabase 로그인 오류:", error.localizedDescription)
-                continuation.resume(throwing: AuthError.appleSignInFailed(error))
+                continuation.resume(throwing: AuthError.signInFailed(.apple, error))
             }
         }
     }

--- a/BestWish/Data/Network/Manager/SocialLogin/Kakao/KakaoLogin.swift
+++ b/BestWish/Data/Network/Manager/SocialLogin/Kakao/KakaoLogin.swift
@@ -32,7 +32,7 @@ extension SupabaseOAuthManager {
             kakaoAuthSession?.cancel()
             kakaoAuthSession = nil
             NSLog("error: \(error.localizedDescription)")
-            throw AuthError.kakaoSignInFailed(error)
+            throw AuthError.signInFailed(.kakao, error)
         }
     }
 

--- a/BestWish/Data/Network/Manager/SupabaseOAuthManager.swift
+++ b/BestWish/Data/Network/Manager/SupabaseOAuthManager.swift
@@ -12,7 +12,6 @@ import Supabase
 
 final class SupabaseOAuthManager: NSObject {
 
-    weak var presentationWindow: UIWindow?
     var continuation: CheckedContinuation<(String, Supabase.Session), Error>?
     var kakaoAuthSession: ASWebAuthenticationSession?
     var currentNonce: String?
@@ -182,9 +181,9 @@ final class SupabaseOAuthManager: NSObject {
 // MARK: - Login할때 하단으로 부터 웹뷰 제어
 extension SupabaseOAuthManager: ASWebAuthenticationPresentationContextProviding, ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return presentationWindow ?? UIWindow()
+        return  UIWindow()
     }
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return presentationWindow ?? UIWindow()
+        return  UIWindow()
     }
 }

--- a/BestWish/Data/Network/Manager/SupabaseOAuthManager.swift
+++ b/BestWish/Data/Network/Manager/SupabaseOAuthManager.swift
@@ -12,10 +12,10 @@ import Supabase
 
 final class SupabaseOAuthManager: NSObject {
 
-    public var continuation: CheckedContinuation<(String, Supabase.Session), Error>?
-    public weak var presentationWindow: UIWindow?
-    public var kakaoAuthSession: ASWebAuthenticationSession?
-    public var currentNonce: String?
+    weak var presentationWindow: UIWindow?
+    var continuation: CheckedContinuation<(String, Supabase.Session), Error>?
+    var kakaoAuthSession: ASWebAuthenticationSession?
+    var currentNonce: String?
 
     let client = SupabaseClient(
         supabaseURL: Bundle.main.supabaseURL,
@@ -23,15 +23,8 @@ final class SupabaseOAuthManager: NSObject {
     )
 
     /// Supabase 토근 확인 및 세션 연결
-    func checkTokenState(_ keychain: KeyChainManager) async -> Bool {
-        // nonisolated read 이므로 await 없이 즉시 반환
-        guard
-            let accessToken = keychain.read(token: .init(service: .access)),
-            let refreshToken = keychain.read(token: .init(service: .refresh))
-            else {
-            NSLog("KeyChain 읽어오기 실패")
-            return false
-        }
+    func checkSupabaseSession(_ keychain: KeyChainManager) async -> Bool {
+        let (accessToken, refreshToken) = chechTokens(keychain)
 
         let session: Supabase.Session
 
@@ -43,13 +36,13 @@ final class SupabaseOAuthManager: NSObject {
 
             Task.detached(priority: .utility) {
                 await keychain.saveAllToken(session: session)
-                NSLog("토큰 로그인 세션 유지 성공")
+                NSLog("로그인 세션 유지 성공")
             }
             return true
         } catch {
             Task.detached(priority: .utility) {
-                NSLog("토큰 로그인 세션 복원 실패:", error.localizedDescription)
                 await keychain.deleteAllToken()
+                NSLog("로그인 세션 복원 실패: \(AuthError.supabaseSetSessionFailed(error).debugDescription)")
             }
             return false
         }
@@ -58,7 +51,7 @@ final class SupabaseOAuthManager: NSObject {
 
     /// 온보딩 필요 유무 확인
     /// Supabase에서 UserInfo 테이블의 role 값 확인 (USER : GUEST = true : false)
-    func checkOnboardingState() async -> Bool {
+    func checkOnboardingState() async throws -> Bool {
         struct Role: Codable { let role: String }
         do {
             let roles: [Role] = try await client
@@ -72,17 +65,21 @@ final class SupabaseOAuthManager: NSObject {
             NSLog("roles: \(roles.map(\.role))") // ["USER"]
             return role == "USER"
         } catch {
-            NSLog("Supabase Request User Role Failed")
-            return false
+            NSLog(AuthError.supabaseRequestRoleFailed(error).debugDescription)
+            throw AuthError.supabaseRequestRoleFailed(error)
         }
 
     }
 
     /// 로그인
-    func signIn(type: SocialType, _ keychain: KeyChainManager) async throws -> Bool {
-        guard let session = try await oauthSessionSignIn(type: type) else { return false }
-        await keychain.saveAllToken(session: session)
-        return await checkOnboardingState()
+    func signIn(type: SocialType, _ keyChain: KeyChainManager) async throws {
+        let session = try await oauthSessionSignIn(type: type)
+
+        if let session = session {
+            Task.detached(priority: .utility) {
+                await keyChain.saveAllToken(session: session)
+            }
+        }
     }
 
     /// 로그아웃
@@ -144,6 +141,19 @@ final class SupabaseOAuthManager: NSObject {
         default:
             return false
         }
+    }
+
+    /// 키체인에 저장된 supabase token 정보 가져오기
+    private func chechTokens(_ keyChain: KeyChainManager) -> (String, String) {
+        // nonisolated read 이므로 await 없이 즉시 반환
+        guard
+            let accessToken = keyChain.read(token: .init(service: .access)),
+            let refreshToken = keyChain.read(token: .init(service: .refresh))
+            else {
+            NSLog(KeyChainError.readError.debugDescription)
+            return ("","")
+        }
+        return (accessToken, refreshToken)
     }
 
     /// 소셜 로그인 OAUTH 인증

--- a/BestWish/Data/Repository/AccountRepositoryImpl.swift
+++ b/BestWish/Data/Repository/AccountRepositoryImpl.swift
@@ -36,12 +36,12 @@ final class AccountRepositoryImpl: AccountRepository {
     }
 
     /// 로그아웃
-    func logout() async throws -> Bool {
-        return try await manager.signOut(keyChain)
+    func logout() async throws {
+        try await manager.signOut(keyChain)
     }
 
     /// 회원탈퇴
-    func withdraw() async throws -> Bool {
+    func withdraw() async throws {
         try await manager.withdraw(keyChain)
     }
 

--- a/BestWish/Data/Repository/AccountRepositoryImpl.swift
+++ b/BestWish/Data/Repository/AccountRepositoryImpl.swift
@@ -20,19 +20,19 @@ final class AccountRepositoryImpl: AccountRepository {
         self.keyChain = keyChain
     }
 
-	/// 로그인 확인
-    func checkTokenState() async -> Bool {
-        await manager.checkTokenState(keyChain)
+    /// Supabase 세션 연결 확인
+    func checkSupabaseSession() async -> Bool {
+        await manager.checkSupabaseSession(keyChain)
     }
 
 	/// 온보딩 확인
-    func checkOnboardingState() async -> Bool {
-        await manager.checkOnboardingState()
+    func checkOnboardingState() async throws -> Bool {
+        try await manager.checkOnboardingState()
     }
 
     /// 로그인
-    func login(type: SocialType) async throws -> Bool {
-        return try await manager.signIn(type: type, keyChain)
+    func login(type: SocialType) async throws {
+        try await manager.signIn(type: type, keyChain)
     }
 
     /// 로그아웃

--- a/BestWish/Domain/Interface/AccountRepository.swift
+++ b/BestWish/Domain/Interface/AccountRepository.swift
@@ -20,8 +20,8 @@ protocol AccountRepository {
     func login(type: SocialType) async throws
 
 	/// 로그아웃
-    func logout() async throws -> Bool
+    func logout() async throws
 
     /// 회원탈퇴
-    func withdraw() async throws -> Bool
+    func withdraw() async throws
 }

--- a/BestWish/Domain/Interface/AccountRepository.swift
+++ b/BestWish/Domain/Interface/AccountRepository.swift
@@ -10,14 +10,14 @@ import Foundation
 /// 계정 관련 레포지토리 프로토콜
 protocol AccountRepository {
 
-	/// 로그인 확인
-    func checkTokenState() async -> Bool
+    /// Supabase 세션 연결 확인
+    func checkSupabaseSession() async -> Bool
 
 	/// 온보딩 확인
-    func checkOnboardingState() async -> Bool
+    func checkOnboardingState() async throws -> Bool
 
 	/// 로그인
-    func login(type: SocialType) async throws -> Bool
+    func login(type: SocialType) async throws
 
 	/// 로그아웃
     func logout() async throws -> Bool

--- a/BestWish/Domain/UseCase/AccountUseCase.swift
+++ b/BestWish/Domain/UseCase/AccountUseCase.swift
@@ -9,8 +9,11 @@ import Foundation
 
 /// 계정 정보 관련 UseCase 프로토콜
 protocol AccountUseCase {
-	/// 로그인	
-	func login(type: SocialType) async throws -> Bool
+    /// 온보딩 유뮤
+    func checkOnboardingState() async throws -> Bool
+    
+    /// 로그인
+    func login(type: SocialType) async throws
 
     /// 로그아웃
     func logout() async throws -> Bool
@@ -27,12 +30,17 @@ final class AccountUseCaseImpl: AccountUseCase {
         self.repository = repository
     }
 
-	/// 로그인    
-	func login(type: SocialType) async throws -> Bool {
+    /// 온보딩 유뮤
+    func checkOnboardingState() async throws -> Bool {
+        try await repository.checkOnboardingState()
+    }
+
+    /// 로그인
+    func login(type: SocialType) async throws {
         try await repository.login(type: type)
     }
 
-	/// 로그아웃
+    /// 로그아웃
     func logout() async throws -> Bool {
         try await repository.logout()
     }

--- a/BestWish/Domain/UseCase/AccountUseCase.swift
+++ b/BestWish/Domain/UseCase/AccountUseCase.swift
@@ -16,10 +16,10 @@ protocol AccountUseCase {
     func login(type: SocialType) async throws
 
     /// 로그아웃
-    func logout() async throws -> Bool
+    func logout() async throws
 
     /// 회원탈퇴
-    func withdraw() async throws -> Bool
+    func withdraw() async throws
 }
 
 /// 계정 정보 관련 UseCase
@@ -41,12 +41,12 @@ final class AccountUseCaseImpl: AccountUseCase {
     }
 
     /// 로그아웃
-    func logout() async throws -> Bool {
+    func logout() async throws {
         try await repository.logout()
     }
 
     /// 회원탈퇴
-    func withdraw() async throws -> Bool {
+    func withdraw() async throws {
         try await repository.withdraw()
     }
 }

--- a/BestWish/Presentation/Scene/Login/ViewController/LoginViewController.swift
+++ b/BestWish/Presentation/Scene/Login/ViewController/LoginViewController.swift
@@ -16,7 +16,6 @@ final class LoginViewController: UIViewController {
     private let loginView = LoginView()
     private let viewModel: LoginViewModel
     private let disposeBag = DisposeBag()
-    private let dummyCoordinator = DummyCoordinator.shared
 
     init(viewModel: LoginViewModel) {
         self.viewModel = viewModel
@@ -46,9 +45,9 @@ final class LoginViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, state in
                 if state {
-                    owner.dummyCoordinator.showMainView()
+                    DummyCoordinator.shared.showMainView()
                 } else {
-                    owner.dummyCoordinator.showOnboardingView()
+                    DummyCoordinator.shared.showOnboardingView()
                 }
             }.disposed(by: disposeBag)
 

--- a/BestWish/Presentation/Scene/Login/ViewController/LoginViewController.swift
+++ b/BestWish/Presentation/Scene/Login/ViewController/LoginViewController.swift
@@ -41,20 +41,18 @@ final class LoginViewController: UIViewController {
         bindKakaoButton()
         bindAppleButton()
 
-        // oauth & 온보딩 결과에 따른 화면 이동
+        /// oauth & 온보딩 결과에 따른 화면 이동
         viewModel.state.readyToUseService
-            .skip(1)
-            .distinctUntilChanged()
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, state in
                 if state {
-                    self.dummyCoordinator.showMainView()
+                    owner.dummyCoordinator.showMainView()
                 } else {
-                    self.dummyCoordinator.showOnboardingView()
+                    owner.dummyCoordinator.showOnboardingView()
                 }
             }.disposed(by: disposeBag)
 
-        // oauth & 온보딩 에러시 alert
+        /// oauth & 온보딩 에러시 alert
         viewModel.state.error
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, error in

--- a/BestWish/Presentation/Scene/Login/ViewModel/LoginViewModel.swift
+++ b/BestWish/Presentation/Scene/Login/ViewModel/LoginViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by yimkeul on 6/7/25.
 //
 
+import RxRelay
 import RxSwift
 
 /// 로그인 View Model
@@ -17,7 +18,10 @@ final class LoginViewModel: ViewModel {
     }
 
     // MARK: - State
-    struct State { }
+    struct State {
+        let readyToUseService: Observable<Bool>
+        let error: Observable<AppError>
+    }
 
     // MARK: - Internal Property
     var action: AnyObserver<Action> { _action.asObserver() }
@@ -25,6 +29,8 @@ final class LoginViewModel: ViewModel {
 
     // MARK: - Private Property
     private let _action = PublishSubject<Action>()
+    private let _readyToUseService = BehaviorRelay<Bool>(value: false)
+    private let _error = PublishSubject<AppError>()
 
     private let useCase: AccountUseCase
     private let disposeBag = DisposeBag()
@@ -32,32 +38,38 @@ final class LoginViewModel: ViewModel {
 
     init(useCase: AccountUseCase) {
         self.useCase = useCase
-        state = State()
+        state = State(
+            readyToUseService: _readyToUseService.asObservable(),
+            error: _error.asObservable()
+        )
         bindAction()
     }
 
     private func bindAction() {
         _action.subscribe(with: self) { owner, action in
             switch action {
-            case .signInKakao:
+            case .signInKakao, .signInApple:
                 Task {
-                    let didOnboarding = try await self.useCase.login(type: .kakao)
-                    if didOnboarding {
-                        self.dummyCoordinator.showMainView()
-                    } else {
-                        self.dummyCoordinator.showOnboardingView()
-                    }
-                }
-            case .signInApple:
-                Task {
-                    let didOnboarding = try await self.useCase.login(type: .apple)
-                    if didOnboarding {
-                        self.dummyCoordinator.showMainView()
-                    } else {
-                        self.dummyCoordinator.showOnboardingView()
+                    do {
+                        let type: SocialType = (action == .signInKakao) ? .kakao : .apple
+                        try await owner.useCase.login(type: type)
+
+                        let didOnboarding = try await owner.useCase.checkOnboardingState()
+                        owner._readyToUseService.accept(didOnboarding)
+                    } catch {
+                        self.handleError(error)
                     }
                 }
             }
         }.disposed(by: disposeBag)
+    }
+
+    /// 에러 핸들링
+    private func handleError(_ error: Error) {
+        if let error = error as? AppError {
+            _error.onNext(error)
+        } else {
+            _error.onNext(AppError.unknown(error))
+        }
     }
 }

--- a/BestWish/Presentation/Scene/Login/ViewModel/LoginViewModel.swift
+++ b/BestWish/Presentation/Scene/Login/ViewModel/LoginViewModel.swift
@@ -29,12 +29,12 @@ final class LoginViewModel: ViewModel {
 
     // MARK: - Private Property
     private let _action = PublishSubject<Action>()
-    private let _readyToUseService = BehaviorRelay<Bool>(value: false)
+
+    private let _readyToUseService = PublishRelay<Bool>()
     private let _error = PublishSubject<AppError>()
 
     private let useCase: AccountUseCase
     private let disposeBag = DisposeBag()
-    private let dummyCoordinator = DummyCoordinator.shared
 
     init(useCase: AccountUseCase) {
         self.useCase = useCase

--- a/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewController/MyPageViewController.swift
+++ b/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewController/MyPageViewController.swift
@@ -108,7 +108,7 @@ final class MyPageViewController: UIViewController {
 
         viewModel.state.isLogOut
             .observe(on: MainScheduler.instance)
-            .bind() { _ in
+            .bind { _ in
                 DummyCoordinator.shared.showLoginView()
             }
             .disposed(by: disposeBag)

--- a/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewController/MyPageViewController.swift
+++ b/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewController/MyPageViewController.swift
@@ -38,7 +38,6 @@ final class MyPageViewController: UIViewController {
             return dataSource.sectionModels[index].footer
         }
     )
-    private let dummyCoordinator = DummyCoordinator.shared
 
     init(viewModel: MyPageViewModel) {
         self.viewModel = viewModel
@@ -108,10 +107,9 @@ final class MyPageViewController: UIViewController {
             .disposed(by: disposeBag)
 
         viewModel.state.isLogOut
-            .filter { $0 }
             .observe(on: MainScheduler.instance)
-            .bind(with: self) { owner, _ in
-                owner.dummyCoordinator.showLoginView()
+            .bind() { _ in
+                DummyCoordinator.shared.showLoginView()
             }
             .disposed(by: disposeBag)
 

--- a/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewController/MyPageViewController.swift
+++ b/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewController/MyPageViewController.swift
@@ -38,6 +38,7 @@ final class MyPageViewController: UIViewController {
             return dataSource.sectionModels[index].footer
         }
     )
+    private let dummyCoordinator = DummyCoordinator.shared
 
     init(viewModel: MyPageViewModel) {
         self.viewModel = viewModel
@@ -104,6 +105,14 @@ final class MyPageViewController: UIViewController {
             .bind(with: self, onNext: { owner, UserInfoModel in
                 owner.setHeaderView(userInfo: UserInfoModel)
             })
+            .disposed(by: disposeBag)
+
+        viewModel.state.isLogOut
+            .filter { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                owner.dummyCoordinator.showLoginView()
+            }
             .disposed(by: disposeBag)
 
         viewModel.state.error

--- a/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewModel/MyPageViewModel.swift
+++ b/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewModel/MyPageViewModel.swift
@@ -21,7 +21,7 @@ final class MyPageViewModel: ViewModel {
     struct State {
         let sections: Observable<[MyPageSection]>
         let userInfo: Observable<UserInfoModel>
-        let isLogOut: Observable<Bool>
+        let isLogOut: Observable<Void>
         let error: Observable<AppError>
     }
 
@@ -34,7 +34,7 @@ final class MyPageViewModel: ViewModel {
 
     private let _sections = PublishSubject<[MyPageSection]>()
     private let _userInfo = PublishSubject<UserInfoModel>()
-    private let _isLogOut = PublishRelay<Bool>()
+    private let _isLogOut = PublishRelay<Void>()
     private let _error = PublishSubject<AppError>()
 
     private let userInfoUseCase: UserInfoUseCase
@@ -106,9 +106,8 @@ final class MyPageViewModel: ViewModel {
         Task {
             do {
                 try await accountUseCase.logout()
-                _isLogOut.accept(true)
+                _isLogOut.accept(())
             } catch {
-                _isLogOut.accept(false)
                 handleError(error)
             }
         }

--- a/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewModel/MyPageViewModel.swift
+++ b/BestWish/Presentation/Scene/MyPage/MyPageMain/ViewModel/MyPageViewModel.swift
@@ -21,6 +21,7 @@ final class MyPageViewModel: ViewModel {
     struct State {
         let sections: Observable<[MyPageSection]>
         let userInfo: Observable<UserInfoModel>
+        let isLogOut: Observable<Bool>
         let error: Observable<AppError>
     }
 
@@ -33,12 +34,12 @@ final class MyPageViewModel: ViewModel {
 
     private let _sections = PublishSubject<[MyPageSection]>()
     private let _userInfo = PublishSubject<UserInfoModel>()
+    private let _isLogOut = PublishRelay<Bool>()
     private let _error = PublishSubject<AppError>()
 
     private let userInfoUseCase: UserInfoUseCase
     private let accountUseCase: AccountUseCase
     private let disposeBag = DisposeBag()
-    private let dummyCoordinator = DummyCoordinator.shared
 
     init(
         userInfoUseCase: UserInfoUseCase,
@@ -49,6 +50,7 @@ final class MyPageViewModel: ViewModel {
         state = State(
             sections: _sections.asObservable(),
             userInfo: _userInfo.asObservable(),
+            isLogOut: _isLogOut.asObservable(),
             error: _error.asObservable()
         )
 
@@ -103,11 +105,10 @@ final class MyPageViewModel: ViewModel {
     private func logout() {
         Task {
             do {
-                let isLogOut = try await accountUseCase.logout()
-                if isLogOut {
-                    self.dummyCoordinator.showLoginView()
-                }
+                try await accountUseCase.logout()
+                _isLogOut.accept(true)
             } catch {
+                _isLogOut.accept(false)
                 handleError(error)
             }
         }

--- a/BestWish/Presentation/Scene/MyPage/UserInfoManagement/ViewController/UserInfoManagementViewController.swift
+++ b/BestWish/Presentation/Scene/MyPage/UserInfoManagement/ViewController/UserInfoManagementViewController.swift
@@ -15,7 +15,6 @@ final class UserInfoManagementViewController: UIViewController {
     private let viewModel: UserInfoManagementViewModel
     private let managementView = UserInfoManagementView()
     private let disposeBag = DisposeBag()
-    private let dummyCoordinator = DummyCoordinator.shared
 
     init(viewModel: UserInfoManagementViewModel) {
         self.viewModel = viewModel
@@ -70,10 +69,9 @@ final class UserInfoManagementViewController: UIViewController {
             }.disposed(by: disposeBag)
 
         viewModel.state.isWithdraw
-            .filter { $0 }
             .observe(on: MainScheduler.instance)
-            .bind(with: self) { owner, _ in
-                owner.dummyCoordinator.showLoginView()
+            .bind { _ in
+                DummyCoordinator.shared.showLoginView()
             }.disposed(by: disposeBag)
 
         viewModel.state.error

--- a/BestWish/Presentation/Scene/MyPage/UserInfoManagement/ViewController/UserInfoManagementViewController.swift
+++ b/BestWish/Presentation/Scene/MyPage/UserInfoManagement/ViewController/UserInfoManagementViewController.swift
@@ -15,6 +15,7 @@ final class UserInfoManagementViewController: UIViewController {
     private let viewModel: UserInfoManagementViewModel
     private let managementView = UserInfoManagementView()
     private let disposeBag = DisposeBag()
+    private let dummyCoordinator = DummyCoordinator.shared
 
     init(viewModel: UserInfoManagementViewModel) {
         self.viewModel = viewModel
@@ -66,6 +67,13 @@ final class UserInfoManagementViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, authProvider in
                 owner.managementView.configure(authProvider: authProvider)
+            }.disposed(by: disposeBag)
+
+        viewModel.state.isWithdraw
+            .filter { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                owner.dummyCoordinator.showLoginView()
             }.disposed(by: disposeBag)
 
         viewModel.state.error

--- a/BestWish/Presentation/Scene/MyPage/UserInfoManagement/ViewModel/UserInfoManagementViewModel.swift
+++ b/BestWish/Presentation/Scene/MyPage/UserInfoManagement/ViewModel/UserInfoManagementViewModel.swift
@@ -22,6 +22,7 @@ final class UserInfoManagementViewModel: ViewModel {
     // MARK: - State
     struct State {
         let authProvider: Observable<String?>
+        let isWithdraw: Observable<Bool>
         let error: Observable<AppError>
     }
 
@@ -32,13 +33,13 @@ final class UserInfoManagementViewModel: ViewModel {
     // MARK: - Private Property
     private let _action = PublishSubject<Action>()
 
-    private let _error = PublishSubject<AppError>()
     private let _authProvider = PublishSubject<String?>()
+    private let _isWithdraw = PublishRelay<Bool>()
+    private let _error = PublishSubject<AppError>()
 
     private let userInfoUseCase: UserInfoUseCase
     private let accountUseCase: AccountUseCase
     private let disposeBag = DisposeBag()
-    private let dummyCoordinator = DummyCoordinator.shared
 
     init(
         userInfoUseCase: UserInfoUseCase,
@@ -48,6 +49,7 @@ final class UserInfoManagementViewModel: ViewModel {
         self.accountUseCase = accountUseCase
         state = State(
             authProvider: _authProvider.asObservable(),
+            isWithdraw: _isWithdraw.asObservable(),
             error: _error.asObservable()
         )
 
@@ -82,14 +84,10 @@ final class UserInfoManagementViewModel: ViewModel {
     private func withdraw() {
         Task {
             do {
-                let isWithdraw = try await accountUseCase.withdraw()
-                if isWithdraw {
-                    let isLogOut = try await accountUseCase.logout()
-                    if isLogOut {
-                        self.dummyCoordinator.showLoginView()
-                    }
-                }
+                try await accountUseCase.withdraw()
+                _isWithdraw.accept(true)
             } catch {
+                _isWithdraw.accept(false)
                 handleError(error)
             }
         }

--- a/BestWish/Presentation/Scene/MyPage/UserInfoManagement/ViewModel/UserInfoManagementViewModel.swift
+++ b/BestWish/Presentation/Scene/MyPage/UserInfoManagement/ViewModel/UserInfoManagementViewModel.swift
@@ -22,7 +22,7 @@ final class UserInfoManagementViewModel: ViewModel {
     // MARK: - State
     struct State {
         let authProvider: Observable<String?>
-        let isWithdraw: Observable<Bool>
+        let isWithdraw: Observable<Void>
         let error: Observable<AppError>
     }
 
@@ -34,7 +34,7 @@ final class UserInfoManagementViewModel: ViewModel {
     private let _action = PublishSubject<Action>()
 
     private let _authProvider = PublishSubject<String?>()
-    private let _isWithdraw = PublishRelay<Bool>()
+    private let _isWithdraw = PublishRelay<Void>()
     private let _error = PublishSubject<AppError>()
 
     private let userInfoUseCase: UserInfoUseCase
@@ -85,9 +85,8 @@ final class UserInfoManagementViewModel: ViewModel {
         Task {
             do {
                 try await accountUseCase.withdraw()
-                _isWithdraw.accept(true)
+                _isWithdraw.accept(())
             } catch {
-                _isWithdraw.accept(false)
                 handleError(error)
             }
         }

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
@@ -20,7 +20,6 @@ final class OnboardingViewController: UIViewController {
     private let disposeBag = DisposeBag()
     private let onboardingViews: [UIView]
     private let returnManager: IQKeyboardReturnManager = .init()
-    private let dummyCoordinator = DummyCoordinator.shared
 
     init(viewModel: OnboardingViewModel, policyViewModel: PolicyViewModel) {
         self.viewModel = viewModel
@@ -92,10 +91,9 @@ final class OnboardingViewController: UIViewController {
 
         /// 온보딩 결과에 따른 화면 이동
         viewModel.state.readyToUseService
-            .filter { $0 }
             .observe(on: MainScheduler.instance)
-            .bind(with: self) { owner, _ in
-                owner.dummyCoordinator.showMainView()
+            .bind() { _ in
+                DummyCoordinator.shared.showMainView()
             }
             .disposed(by: disposeBag)
 

--- a/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewController/OnboardingViewController.swift
@@ -92,7 +92,7 @@ final class OnboardingViewController: UIViewController {
         /// 온보딩 결과에 따른 화면 이동
         viewModel.state.readyToUseService
             .observe(on: MainScheduler.instance)
-            .bind() { _ in
+            .bind { _ in
                 DummyCoordinator.shared.showMainView()
             }
             .disposed(by: disposeBag)

--- a/BestWish/Presentation/Scene/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -32,7 +32,7 @@ final class OnboardingViewModel: ViewModel {
         let isValidNickname: Observable<Bool?>
         let currentPage: Observable<Int>
         let showPolicySheet: Observable<Void>
-        let readyToUseService: Observable<Bool>
+        let readyToUseService: Observable<Void>
         let error: Observable<AppError>
     }
 
@@ -47,7 +47,7 @@ final class OnboardingViewModel: ViewModel {
     private let _isValidNickname = BehaviorRelay<Bool?>(value: nil)
     private let _currentPage = BehaviorRelay<Int> (value: OnboardingViewModel.onboardingStartPage)
     private let _showPolicySheet = PublishRelay<Void>()
-    private let _readyToUseService = PublishRelay<Bool>()
+    private let _readyToUseService = PublishRelay<Void>()
     private let _error = PublishSubject<AppError>()
 
     /// 총 페이지수
@@ -124,9 +124,8 @@ final class OnboardingViewModel: ViewModel {
                 nickname: userInfo.nickname,
                 gender: userInfo.gender,
                 birth: userInfo.birth)
-            _readyToUseService.accept(true)
+            _readyToUseService.accept(())
         } catch {
-            _readyToUseService.accept(false)
             handleError(error)
         }
     }

--- a/BestWish/Presentation/Scene/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/BestWish/Presentation/Scene/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -32,6 +32,8 @@ final class OnboardingViewModel: ViewModel {
         let isValidNickname: Observable<Bool?>
         let currentPage: Observable<Int>
         let showPolicySheet: Observable<Void>
+        let readyToUseService: Observable<Bool>
+        let error: Observable<AppError>
     }
 
     // MARK: - Internal Property
@@ -42,9 +44,10 @@ final class OnboardingViewModel: ViewModel {
     private let _action = PublishSubject<Action>()
 
     private let _userInfo = BehaviorRelay<UserInfoModel?> (value: nil)
-    private let _currentPage = BehaviorRelay<Int> (value: OnboardingViewModel.onboardingStartPage)
     private let _isValidNickname = BehaviorRelay<Bool?>(value: nil)
+    private let _currentPage = BehaviorRelay<Int> (value: OnboardingViewModel.onboardingStartPage)
     private let _showPolicySheet = PublishRelay<Void>()
+    private let _readyToUseService = PublishRelay<Bool>()
     private let _error = PublishSubject<AppError>()
 
     /// 총 페이지수
@@ -56,7 +59,6 @@ final class OnboardingViewModel: ViewModel {
 
     private let useCase: UserInfoUseCase
     private let disposeBag = DisposeBag()
-    private let dummyCoordinator = DummyCoordinator.shared
 
     init(useCase: UserInfoUseCase) {
         self.useCase = useCase
@@ -64,7 +66,9 @@ final class OnboardingViewModel: ViewModel {
             userInfo: _userInfo.asObservable(),
             isValidNickname: _isValidNickname.asObservable(),
             currentPage: _currentPage.asObservable(),
-            showPolicySheet: _showPolicySheet.asObservable()
+            showPolicySheet: _showPolicySheet.asObservable(),
+            readyToUseService: _readyToUseService.asObservable(),
+            error: _error.asObservable()
         )
         bindAction()
     }
@@ -94,8 +98,6 @@ final class OnboardingViewModel: ViewModel {
             case .uploadUserInfo(let userInfo):
                 Task {
                     await self.updateUserInfo(with: userInfo)
-                    // TODO: Coordinator 패턴 적용하기
-                    self.dummyCoordinator.showMainView()
                 }
             }
         }.disposed(by: disposeBag)
@@ -122,7 +124,9 @@ final class OnboardingViewModel: ViewModel {
                 nickname: userInfo.nickname,
                 gender: userInfo.gender,
                 birth: userInfo.birth)
+            _readyToUseService.accept(true)
         } catch {
+            _readyToUseService.accept(false)
             handleError(error)
         }
     }


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - DummyCoordinator의 싱글톤 호출을 ViewController에서 호출하도록 설정
 - 화면 이동이 필요한 부분은 ViewModel의 State에 값 추가 후 ViewController에서 바인딩
 - 이전 PR에서 AccountRepository의 logout, withdraw, login의 리턴을 Bool 에서 Void로 변경
 - withdraw구조개선 ( supabase에서 row을 지운후 기기의 KeyChain만 지우는 걸로 변경. 기존에는 row 지우고 로그아웃까지 호출했지만 필요없는 기능임을 확인)

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone - | <img src = "" width ="250"> |

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #135 
