### PR TITLE
Fix/#190 v.1.0.4 keychain 로직 개선, 회원탈퇴 UX 개선

### DIFF
--- a/BestWishData/Data/Network/Error/AuthError.swift
+++ b/BestWishData/Data/Network/Error/AuthError.swift
@@ -21,6 +21,7 @@ enum AuthError: AppErrorProtocol {
     case supabaseSetSessionFailed(Error)
     case missProvider
     case supabaseRequestRoleFailed(Error)
+    case supabaseRPCFailed(Error)
 }
 
 // MARK: - AuthError 케이스 별 텍스트
@@ -55,6 +56,8 @@ extension AuthError {
             "Supabase Request Client Secret Return Nil"
         case let .supabaseSetSessionFailed(error):
             "Supabase Set Session Failed : \(error.localizedDescription)"
+        case let .supabaseRPCFailed(error):
+            "Supabase RPC Failed : \(error.localizedDescription)"
         case .missProvider:
             "Missing Provider"
 

--- a/BestWishPresentation/Presentation/Scene/Alert/AlertViewController.swift
+++ b/BestWishPresentation/Presentation/Scene/Alert/AlertViewController.swift
@@ -54,9 +54,11 @@ final class AlertViewController: UIViewController {
 
         alertView.confirmButton.rx.tap
             .bind(with: self) { owner, _ in
-                owner.confirmAction?()
-                owner.dismiss(animated: true)
-            }.disposed(by: disposeBag)
+                owner.dismiss(animated: true) {
+                    owner.confirmAction?()
+                }
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/BestWishPresentation/Presentation/Scene/MyPage/UserInfoManagement/ViewController/Subview/UserInfoManagementView.swift
+++ b/BestWishPresentation/Presentation/Scene/MyPage/UserInfoManagement/ViewController/Subview/UserInfoManagementView.swift
@@ -34,10 +34,12 @@ final class UserInfoManagementView: UIView {
         title: "회원 정보를 삭제하시겠어요?",
         subTitle: "회원탈퇴"
     )
+    private let _activityIndicator = UIActivityIndicatorView(style: .large)
 
     // MARK: - Internal Property
     var userInfoArrowButton: UIButton { _userInfoHorizontalStackView.arrowButton }
     var withdrawButton: UIButton { _withdrawStackView.arrowButton }
+    var activityIndicator: UIActivityIndicatorView { _activityIndicator }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -58,6 +60,13 @@ final class UserInfoManagementView: UIView {
     func addUnderLine() {
         _snsInfoHorizontalStackView.addUnderLine()
     }
+
+    func showLoading(_ loading: Bool) {
+        _activityIndicator.isHidden = !loading
+        loading
+            ? _activityIndicator.startAnimating()
+            : _activityIndicator.stopAnimating()
+    }
 }
 
 // MARK: - View 설정
@@ -70,10 +79,15 @@ private extension UserInfoManagementView {
 
     func setAttributes() {
         self.backgroundColor = .gray0
+        _activityIndicator.do {
+            $0.color = .primary400
+            $0.hidesWhenStopped = true
+            $0.isHidden = true
+        }
     }
 
     func setHierarchy() {
-        self.addSubviews(_stackView)
+        self.addSubviews(_stackView, _activityIndicator)
         _stackView.addArrangedSubviews(_userInfoManagementStackView, _snsInfoStackView)
         _userInfoManagementStackView.addArrangedSubviews(
             _userInfoManagementTitlelabel,
@@ -90,6 +104,9 @@ private extension UserInfoManagementView {
         _stackView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide).inset(32)
             $0.directionalHorizontalEdges.equalToSuperview().inset(20)
+        }
+        _activityIndicator.snp.makeConstraints {
+            $0.center.equalToSuperview()
         }
     }
 }

--- a/BestWishPresentation/Presentation/Scene/MyPage/UserInfoManagement/ViewController/UserInfoManagementViewController.swift
+++ b/BestWishPresentation/Presentation/Scene/MyPage/UserInfoManagement/ViewController/UserInfoManagementViewController.swift
@@ -57,9 +57,7 @@ public final class UserInfoManagementViewController: UIViewController {
         managementView.withdrawButton.rx.tap
             .bind(with: self) { owner, _ in
                 AlertBuilder(baseViewController: owner, type: .withdraw) {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                        owner.viewModel.action.onNext(.withdraw)
-                    }
+                    owner.viewModel.action.onNext(.withdraw)
                 }.show()
             }.disposed(by: disposeBag)
     }

--- a/BestWishPresentation/Presentation/Scene/MyPage/UserInfoManagement/ViewController/UserInfoManagementViewController.swift
+++ b/BestWishPresentation/Presentation/Scene/MyPage/UserInfoManagement/ViewController/UserInfoManagementViewController.swift
@@ -76,6 +76,13 @@ public final class UserInfoManagementViewController: UIViewController {
 //                DummyCoordinator.shared.showLoginView()
             }.disposed(by: disposeBag)
 
+        viewModel.state.isLoading
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, isLoading in
+                owner.managementView.showLoading(isLoading)
+            }
+            .disposed(by: disposeBag)
+
         viewModel.state.error
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, error in

--- a/BestWishPresentation/Presentation/Scene/MyPage/UserInfoManagement/ViewModel/UserInfoManagementViewModel.swift
+++ b/BestWishPresentation/Presentation/Scene/MyPage/UserInfoManagement/ViewModel/UserInfoManagementViewModel.swift
@@ -25,6 +25,7 @@ public final class UserInfoManagementViewModel: ViewModel {
         let authProvider: Observable<String?>
         let isWithdraw: Observable<Void>
         let error: Observable<AppError>
+        let isLoading: Observable<Bool>
     }
 
     // MARK: - Internal Property
@@ -37,6 +38,7 @@ public final class UserInfoManagementViewModel: ViewModel {
     private let _authProvider = PublishSubject<String?>()
     private let _isWithdraw = PublishRelay<Void>()
     private let _error = PublishSubject<AppError>()
+    private let _isLoading = PublishRelay<Bool>()
 
     private let userInfoUseCase: UserInfoUseCase
     private let accountUseCase: AccountUseCase
@@ -51,7 +53,8 @@ public final class UserInfoManagementViewModel: ViewModel {
         state = State(
             authProvider: _authProvider.asObservable(),
             isWithdraw: _isWithdraw.asObservable(),
-            error: _error.asObservable()
+            error: _error.asObservable(),
+            isLoading: _isLoading.asObservable()
         )
 
         bindAction()
@@ -83,7 +86,11 @@ public final class UserInfoManagementViewModel: ViewModel {
 
     /// 회원 탈퇴
     private func withdraw() {
+        _isLoading.accept(true)
         Task {
+            defer {
+                    _isLoading.accept(false)
+            }
             do {
                 try await accountUseCase.withdraw()
                 _isWithdraw.accept(())


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 키체인 삭제 로직 개선
 - 회원탈퇴 진행시 activityIndicator 넣기
- 회원탈퇴 모달 dismiss 될때 시점확인해서 회원탈퇴 메서드 진행하도록 개선


## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
기존 AlertViewController에서 confirmButton버튼이 눌렸을때의 로직을 수정했습니다. (2번째 커밋 확인)

해당 로직을 변경함으로써 회원탈퇴 시 DispatchQueue로 1초 대기하는 코드가 삭제되었습니다.


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone - 15 Pro | |

https://github.com/user-attachments/assets/0104a028-2a05-4ce0-b0d7-e743f216cc3f


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #190 
