### PR TITLE
Feature/#212 platform link alert update

### DIFF
--- a/BestWishData/Data/Util/String+Util.swift
+++ b/BestWishData/Data/Util/String+Util.swift
@@ -37,7 +37,16 @@ extension String {
             return Int(result[numberRange])
         }
     }
-    
+
+    /// 특정 쿼리 파라미터 값을 추출하는 메서드
+    func extractQueryValue(for key: String) -> String? {
+        guard let components = URLComponents(string: self),
+              let queryItems = components.queryItems else {
+            return nil
+        }
+        return queryItems.first(where: { $0.name == key })?.value
+    }
+
     /// 딥링크 → 사이트 링크 (상품 페이지 URL 추출)
     func convertDeepLinkToProductURL(_ type: PlatformEntity) -> String {
         guard let url = URLComponents(string: self),
@@ -77,15 +86,11 @@ extension String {
             let productId = self.replacingOccurrences(of: domain, with: "")
             return "aglo://webview?url=https://4910.kr/goods/\(productId)"
         case .hiver:
-            let domain = "https://www.hiver.co.kr/onelink?type=products"
-            guard self.contains(domain) else { return self }
-            let productId = self.replacingOccurrences(of: domain, with: "")
-            return "hiverapplication://applink/products/\(productId)"
+            return self.extractQueryValue(for: "deep_link_value") ?? "hiverapplication://applink/products/\(String(describing: self.extractQueryValue(for: "id")))"
         default: return self
         }
     }
 }
-
 
 // MARK: 무신사
 // 앱을 통해 복사한 링크

--- a/BestWishPresentation/Presentation/Extension/PlatformEntity+Extension.swift
+++ b/BestWishPresentation/Presentation/Extension/PlatformEntity+Extension.swift
@@ -14,7 +14,12 @@ extension PlatformEntity {
     init?(index: Int) {
         self = Self.allCases[index]
     }
-    
+
+    init?(text: String) {
+        guard let matchedCase = Self.allCases.first(where: { text.contains($0.platformImage) }) else { return nil }
+        self = matchedCase
+    }
+
     var platformName: String {
         switch self {
         case .all:
@@ -35,6 +40,8 @@ extension PlatformEntity {
             return "4910"
         case .hiver:
             return "하이버"
+        default:
+            return "notFound"
         }
     }
 
@@ -58,6 +65,8 @@ extension PlatformEntity {
             return "4910"
         case .hiver:
             return "hiver"
+        default:
+            return "notFound"
         }
     }
 
@@ -73,10 +82,10 @@ extension PlatformEntity {
             return "https://kream.airbridge.io/home/"
         case .brandi:
             return "https://brandi.onelink.me/8g7c"
-        case ._4910:
-            return "aglo://home?airbridge_referrer=airbridge%3Dtrue%26event_uuid%3D8ed4e8ae-1983-41e9-9154-8da059900105%26client_id%3D73e2acf9-488d-48ce-b25d-f9694aaf8fdf%26channel%3Dairbridge.websdk%26referrer_timestamp%3D1751044207184"
         case ._29cm:
             return "https://29cm.onelink.me/1080201211"
+        case ._4910:
+            return "aglo://home?4910"
         case .hiver:
             return "hiverapplication://applink" //"https://hiver.onelink.me/orq2"
         default:
@@ -84,9 +93,56 @@ extension PlatformEntity {
         }
     }
     // "hiverapplication%3A%2F%2Fapplink%2Fproducts%2F\(productId)%3Fsearch-word%3D%25EB%25B0%2598%25ED%258C%2594"
-    
+
+    var platformWebLink: String {
+        switch self {
+        case .musinsa:
+            return "https://www.musinsa.com/main/musinsa/recommend"
+        case .zigzag:
+            return "https://zigzag.kr/?utm_source=sa_google_mo&utm_campaign=sa_01_all_zigzag&utm_medium=search&utm_term=지그재그&utm_content=main&ad_creative=764500111335&ad_group=zk_zk_zigzag_all&campaign=sa_01_all_zigzag&content=main&og_tag_id=144505773&routing_short_id=cc6743&sub_id=search&sub_id_2=kwd-318529266133&term=지그재그&tracking_template_id=7f11ae9bbc3aa24313dbc0a6c6e394b1&ad_type=click&gad_source=1&gad_campaignid=22577300122&gbraid=0AAAAApcZMC9PzOkvaHz_Q7V7IH7uCcK3g&https_deeplink=true&airbridge_referrer=airbridge%3Dtrue%26client_id%3D3a6d0da4-115c-489f-913e-e5854779d00d%26event_uuid%3Dd4015b08-daa7-466d-90da-bda83d734227%26referrer_timestamp%3D1753162143017%26channel%3Dsa_google_mo%26campaign%3Dsa_01_all_zigzag%26tracking_template_id%3D7f11ae9bbc3aa24313dbc0a6c6e394b1%26ad_group%3Dzk_zk_zigzag_all%26ad_creative%3D764500111335%26content%3Dmain%26term%3D%25EC%25A7%2580%25EA%25B7%25B8%25EC%259E%25AC%25EA%25B7%25B8%26sub_id%3Dsearch%26sub_id_2%3Dkwd-318529266133%26og_tag_id%3D144505773%26routing_short_id%3Dcc6743"
+        case .ably:
+            return "https://m.a-bly.com"
+        case .kream:
+            return "https://kream.co.kr/?utm_source=google&utm_medium=cpc&utm_campaign=NEW_자사명_수동_MO&utm_term=크림&utm_content=A.+자사명_수동&gad_source=1&gad_campaignid=20006289046&gbraid=0AAAAACRs-HvayVsOKpI5U2j12Y-p_jrlw"
+        case .brandi:
+            return "https://www.brandi.co.kr/?srsltid=AfmBOoq85X5prwYGp7hcXuBh_9LvCeImZB4EDQ329-lca7-FKfFTraeL"
+        case ._4910:
+            return "https://4910.kr/?srsltid=AfmBOoqnW3scR3TDYm6-3MxFF_VoaY6-5D4oVQKlJBvXAUXlueiH0O-W&tab=recommend"
+        case ._29cm:
+            return "https://www.29cm.co.kr"
+        case .hiver:
+            return "https://www.hiver.co.kr/?gad_source=1&gad_campaignid=22112879411&gbraid=0AAAAAC3D2P3i-J7qTcZNnXU-7D3I8_qOZ"
+        default:
+            return "notFound"
+        }
+    }
+
+    var platformAppStoreLink: String {
+        switch self {
+        case .musinsa:
+            return "https://apps.apple.com/kr/app/%EC%98%A8%EB%9D%BC%EC%9D%B8-%ED%8C%A8%EC%85%98-%EC%8A%A4%ED%86%A0%EC%96%B4-%EB%AC%B4%EC%8B%A0%EC%82%AC/id1003139529"
+        case .zigzag:
+            return "https://apps.apple.com/kr/app/%EC%A7%80%EA%B7%B8%EC%9E%AC%EA%B7%B8-zigzag/id976131101"
+        case .ably:
+            return "https://apps.apple.com/kr/app/%EC%97%90%EC%9D%B4%EB%B8%94%EB%A6%AC-%EC%A0%84-%EC%83%81%ED%92%88-%EB%AC%B4%EB%A3%8C%EB%B0%B0%EC%86%A1/id1084960428"
+        case .kream:
+            return "https://apps.apple.com/kr/app/kream-%ED%81%AC%EB%A6%BC-no-1-%ED%95%9C%EC%A0%95%ED%8C%90-%EA%B1%B0%EB%9E%98-%ED%94%8C%EB%9E%AB%ED%8F%BC/id1490580239"
+        case .brandi:
+            return "https://apps.apple.com/kr/app/%EB%B8%8C%EB%9E%9C%EB%94%94-%EC%9D%B8%EA%B8%B0-%EC%87%BC%ED%95%91%EB%AA%B0%EC%9D%84-%ED%95%9C%EA%B3%B3%EC%97%90/id1005442353"
+        case ._4910:
+            return "https://apps.apple.com/kr/app/4910-%ED%8C%A8%EC%85%98%EC%9D%B4-%EC%89%AC%EC%9B%8C%EC%A7%80%EB%8A%94-%EC%88%9C%EA%B0%84/id6449024239"
+        case ._29cm:
+            return "https://apps.apple.com/kr/app/29cm/id789634744"
+        case .hiver:
+            return "https://apps.apple.com/kr/app/%ED%95%98%EC%9D%B4%EB%B2%84-%EB%82%A8%EC%9E%90%EB%93%A4%EC%9D%98-%ED%95%A9%EB%A6%AC%EC%A0%81-%ED%8C%A8%EC%85%98-%EC%87%BC%ED%95%91/id1346503383"
+        default:
+            return "notFound"
+        }
+    }
+
     func searchResultDeepLink(keyword: String) -> String {
         guard let encoded = keyword.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return "" }
+
         switch self {
         case .musinsa:
             return "https://musinsaapp.page.link/?link=https%3A%2F%2Fwww.musinsa.com%2Fsearch%2Fgoods%3Fkeyword%3D\(encoded)%26keywordType%3Dpopular%26gf%3DA%26_gf%3DA&apn=com.musinsa.store&isi=1003139529&ibi=com.grab.musinsa&efr=1"
@@ -98,14 +154,14 @@ extension PlatformEntity {
             return "https://kream.airbridge.io/search?keyword=\(encoded)&tab=products&footer=home&deeplink_url=kreamapp%3A%2F%2Fsearch%3Fkeyword%3D\(encoded)%26tab%3Dproducts%26footer%3Dhome&fallback_ios=itunes-appstore&ab_airpage=0&abi_skip_tk=1&airbridge_referrer=airbridge%3Dtrue%26client_id%3D692b8874-5eb9-49a0-a37f-97e31f0eec87%26channel%3Dgoogle%26campaign%3DNEW_%25EC%259E%2590%25EC%2582%25AC%25EB%25AA%2585_%25EC%2588%2598%25EB%258F%2599_MO%26content%3DA.%252B%25EC%259E%2590%25EC%2582%25AC%25EB%25AA%2585_%25EC%2588%2598%25EB%258F%2599%26medium%3Dcpc%26term%3Dkream%26referrer_timestamp%3D1751004482626%26tp_gen_type%3D1221%26keyword%3D\(encoded)%26tab%3Dproducts%26footer%3Dhome%26cta_param_1%3Dweb%2520to%2520app%26cta_param_2%3Dbanner"
         case .brandi:
             return "https://www.brandi.co.kr/search?q=\(encoded)"
-        case ._4910:
-            return "https://4910.kr/search?query=\(encoded)&search_type=DIRECT)"
         case ._29cm:
             return "https://29cm.onelink.me/1080201211?af_js_web=true&af_ss_ver=2_7_3&pid=29cm_mowebtoapp&c=install_mowebtoapp&af_ad=top_banner&is_retargeting=true&af_click_lookback=7d&af_ss_ui=true&af_sub5=https://www.29cm.co.kr/&af_dp=app29cm%3A%2F%2Fweb%2Fhttps%3A%2F%2Fshop.29cm.co.kr%2Fsearch%3Fkeyword%3D\(encoded)%26sort%3DRECOMMEND%26sortOrder%3DDESC%26defaultSort%3DRECOMMEND%26keywordTypes%3D&deep_link_value=app29cm%3A%2F%2Fweb%2Fhttps%3A%2F%2Fshop.29cm.co.kr%2Fsearch%3Fkeyword%3D\(encoded)%26sort%3DRECOMMEND%26sortOrder%3DDESC%26defaultSort%3DRECOMMEND%26keywordTypes%3D&af_web_dp=https%3A%2F%2Fshop.29cm.co.kr%2Fsearch%3Fkeyword%3D\(encoded)%26sort%3DRECOMMEND%26sortOrder%3DDESC%26defaultSort%3DRECOMMEND%26keywordTypes%3D"
+        case ._4910:
+            return "https://4910.kr/search?query=\(encoded)&search_type=DIRECT)"
         case .hiver:
-            return "https://www.hiver.co.kr/search?q=\(encoded)"
-            //"hiverapplication://applink/https://www.hiver.co.kr/search?q=\(encoded)"
-        default: return "notFound"
+            return "https://www.hiver.co.kr/search?q=\(encoded)" //"hiverapplication://applink/https://www.hiver.co.kr/search?q=\(encoded)"
+        default:
+            return "notFound"
         }
     }
 }

--- a/BestWishPresentation/Presentation/Extension/UIViewController+Extension.swift
+++ b/BestWishPresentation/Presentation/Extension/UIViewController+Extension.swift
@@ -80,4 +80,25 @@ extension UIViewController {
         alertController.addAction(confirmAction)
         present(alertController, animated: true)
     }
+
+    func showDeepLinkAlert() {
+        let alertController = UIAlertController(
+            title: "해당 앱이 설치되어 있지 않습니다.",
+            message: "원하시는 실행 방법을 선택해 주세요.",
+            preferredStyle: .alert
+        )
+        
+        let webAction = UIAlertAction(title: "웹으로 이동", style: .default) { _ in
+            UIApplication.shared.open(URL(string: "https://www.naver.com")!)
+        }
+
+        let appStoreAction = UIAlertAction(title: "앱스토어로 이동", style: .default) { _ in
+            UIApplication.shared.open(URL(string: "https://apps.apple.com/kr/app/%EB%B2%A0%EC%8A%A4%ED%8A%B8%EC%9C%84%EC%8B%9C/id6747424430")!)
+        }
+
+        alertController.addAction(webAction)
+        alertController.addAction(appStoreAction)
+
+        present(alertController, animated: true)
+    }
 }

--- a/BestWishPresentation/Presentation/Extension/UIViewController+Extension.swift
+++ b/BestWishPresentation/Presentation/Extension/UIViewController+Extension.swift
@@ -5,6 +5,7 @@
 //  Created by 이수현 on 6/9/25.
 //
 
+import BestWishDomain
 import UIKit
 
 extension UIViewController {
@@ -81,19 +82,21 @@ extension UIViewController {
         present(alertController, animated: true)
     }
 
-    func showDeepLinkAlert() {
+    func showDeepLinkAlert(_ link: String) {
         let alertController = UIAlertController(
             title: "해당 앱이 설치되어 있지 않습니다.",
             message: "원하시는 실행 방법을 선택해 주세요.",
             preferredStyle: .alert
         )
-        
+
+        guard let platformEntity = PlatformEntity(text: link) else { return }
+
         let webAction = UIAlertAction(title: "웹으로 이동", style: .default) { _ in
-            UIApplication.shared.open(URL(string: "https://www.naver.com")!)
+            UIApplication.shared.open(URL(string: platformEntity.platformWebLink)!)
         }
 
         let appStoreAction = UIAlertAction(title: "앱스토어로 이동", style: .default) { _ in
-            UIApplication.shared.open(URL(string: "https://apps.apple.com/kr/app/%EB%B2%A0%EC%8A%A4%ED%8A%B8%EC%9C%84%EC%8B%9C/id6747424430")!)
+            UIApplication.shared.open(URL(string: platformEntity.platformAppStoreLink)!)
         }
 
         alertController.addAction(webAction)

--- a/BestWishPresentation/Presentation/Scene/Anlaysis/ViewModel/AnalysisViewModel.swift
+++ b/BestWishPresentation/Presentation/Scene/Anlaysis/ViewModel/AnalysisViewModel.swift
@@ -40,7 +40,7 @@ public final class AnalysisViewModel: ViewModel {
     let state: State
     
     // MARK: - Private Property
-    private var previousCategory = ""                       // 카테고리 비교 용도
+    private var previousCategory = ""                                // 카테고리 비교 용도
     private var currentQuery = BehaviorRelay<String>(value: "")
     private var currentPlatform = BehaviorRelay<PlatformEntity?>(value: nil)
     

--- a/BestWishPresentation/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/BestWishPresentation/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -242,12 +242,14 @@ private extension HomeViewController {
             return
         }
 
-        UIApplication.shared.open(url) { success in
+        UIApplication.shared.open(url) { [weak self] success in
+            guard let self else { return }
+
             if success {
                 NSLog("✅ 앱 전환 성공: \(url.absoluteString)")
             } else {
                 NSLog("❌ 앱 전환 실패: \(url.absoluteString)")
-                self.showBasicAlert(title: "미지원 플랫폼", message: "해당 플랫폼은 추후 업데이트될 예정입니다.\n감사합니다.")
+                self.showDeepLinkAlert()
             }
         }
     }

--- a/BestWishPresentation/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/BestWishPresentation/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 백래훈 on 6/10/25.
 //
 
+import BestWishDomain
 import UIKit
 
 internal import RxDataSources
@@ -249,7 +250,7 @@ private extension HomeViewController {
                 NSLog("✅ 앱 전환 성공: \(url.absoluteString)")
             } else {
                 NSLog("❌ 앱 전환 실패: \(url.absoluteString)")
-                self.showDeepLinkAlert()
+                self.showDeepLinkAlert(link)
             }
         }
     }


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 플랫폼 바로가기(무신사, 지그재그, 에이블리, KREAM, 브랜디, 29CM, 4910, 하이버)에 필요한 외부 쇼핑몰 앱이 기기에 설치되어 있지 않은 경우의 사용자 경험(UX) 개선 완료
 - 해당 앱이 설치되어 있지 않으면 ‘미지원 플랫폼’이라는 모호한 Alert 출력 및 현재는 8개 플랫폼을 모두 지원 중인 상태 -> ‘웹으로 이동’ 또는 ‘앱스토어에서 설치’ 선택지를 제공하는 Alert로 개선
 - Universial Link를 지원하는 플랫폼은 자동으로 Safari 전환 가능
 - 반면 Deep Link를 지원하는 플랫폼은 별도의 분기 처리 및 Alert 출력이 필요했음
 - 동일한 앱이지만 플랫폼 바로가기는 Universial Link, 위시리스트는 Deep Link를 지원하는 플랫폼 존재 (브랜디, 29cm)
   - 상품 상세 페이지는 Deep Link를 지원하는 것으로 보아 플랫폼 바로가기도 Deep Link를 지원할 것으로 파악됨
 - Universial Link는 'https://' 형태의 웹 주소 링크이며 링크 자체가 앱 전환을 발생, 해당 앱이 존재하지 않을 경우 자동으로 App Store 전환 유도
 - Deep Link는 'zigzag://'의 Scheme 형태이며 Scheme은 URL 형태가 아니기 때문에 따로 Alert 분기 처리 필요

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- 앱 미설치 상태 시 Alert 출력 문구 확인
- '웹 페이지 이동', '앱스토어 이동' 정상 동작 확인

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| **Before** | 스크린샷(또는 GIF) | **After** | 스크린샷(또는 GIF) |
| :-------------: | :----------: | :-------------: | :----------: |
| **플랫폼 바로가기**</br>**(앱 미설치 상태)**</br>Alert</br>[iPhone 13 Pro] | <img src = "https://github.com/user-attachments/assets/38324c53-4ab2-47e7-b7c5-72c1d8d0f0b4" width ="250"> | **플랫폼 바로가기**</br>**(앱 미설치 상태)**</br>Alert</br>[iPhone 13 Pro] | <img src = "https://github.com/user-attachments/assets/615816b8-8e84-45d7-ac77-c9c365ac7e4a" width ="250"> |
| - | - | **Universial Link**</br>자동 전환</br>[iPhone 13 Pro] | <img src = "https://github.com/user-attachments/assets/96af594d-1ed8-4a28-bf1e-1e2c642939b0" width ="250"> |
| - | - | **웹으로 이동**</br>[iPhone 13 Pro] | <img src = "https://github.com/user-attachments/assets/a3c78032-4601-42f2-b4b9-5411ddd776be" width ="250"> |
| - | - | **앱스토어로 이동**</br>[iPhone 13 Pro] | <img src = "https://github.com/user-attachments/assets/e37a1722-2fb3-43ff-8d75-df3d5abf42d3" width ="250"> |


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #212 


